### PR TITLE
Fix customer resource variables and cleanup service

### DIFF
--- a/tnp-backend/app/Http/Resources/V1/CustomerResource.php
+++ b/tnp-backend/app/Http/Resources/V1/CustomerResource.php
@@ -23,9 +23,7 @@ class CustomerResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
-        static $cus_no_r, $cus_channel_r, $cus_tel_1_r, $cus_tel_2_r;
-
-        $cus_no_r = str_pad($this->cus_no, 6, '0', STR_PAD_LEFT); // เติมเลข 0 ด้านหน้า cus_no ให้ครบ 6 หลัก
+        $cus_no_r  = str_pad($this->cus_no, 6, '0', STR_PAD_LEFT); // เติมเลข 0 ด้านหน้า cus_no ให้ครบ 6 หลัก
         $cus_tel_1_r = $this->globalService->formatThaiPhoneNumber($this->cus_tel_1);
         $cus_tel_2_r = $this->globalService->formatThaiPhoneNumber($this->cus_tel_2);
 

--- a/tnp-backend/app/Services/CustomerService.php
+++ b/tnp-backend/app/Services/CustomerService.php
@@ -3,7 +3,6 @@
 namespace App\Services;
 
 use App\Models\Worksheet\Customer;
-use Illuminate\Support\Facades\DB;
 use DateTime;
 use Carbon\Carbon;
 


### PR DESCRIPTION
## Summary
- avoid static variables for data formatting in customer resource
- remove unused DB import from customer service

## Testing
- `php -l app/Http/Resources/V1/CustomerResource.php`
- `php -l app/Services/CustomerService.php`


------
https://chatgpt.com/codex/tasks/task_e_68661f5d2ea88328abd89607437d1872