### PR TITLE
Improve customer duplication checks

### DIFF
--- a/tnp-backend/app/Http/Controllers/Api/V1/Customers/CustomerController.php
+++ b/tnp-backend/app/Http/Controllers/Api/V1/Customers/CustomerController.php
@@ -777,18 +777,22 @@ class CustomerController extends Controller
         $email = $request->query('email');
         $exclude = $request->query('exclude');
 
+        if (!$tel && !$email) {
+            return response()->json(['exists' => false]);
+        }
+
         $query = Customer::query();
 
-        if ($tel) {
-            $query->where(function ($q) use ($tel) {
+        $query->where(function ($q) use ($tel, $email) {
+            if ($tel) {
                 $q->where('cus_tel_1', $tel)
                   ->orWhere('cus_tel_2', $tel);
-            });
-        }
+            }
 
-        if ($email) {
-            $query->orWhere('cus_email', $email);
-        }
+            if ($email) {
+                $q->orWhere('cus_email', $email);
+            }
+        });
 
         if ($exclude) {
             $query->where('cus_id', '!=', $exclude);

--- a/tnp-backend/app/Http/Controllers/Api/V1/Customers/CustomerController.php
+++ b/tnp-backend/app/Http/Controllers/Api/V1/Customers/CustomerController.php
@@ -263,32 +263,7 @@ class CustomerController extends Controller
         // Clean เบอร์โทรศัพท์ & Tax ID อัตโนมัติ
         $this->sanitizeContactFields($data_input);
 
-        // Check for duplicate phone or email (excluding current record)
-        $duplicate = Customer::query()
-            ->where('cus_id', '!=', $id)
-            ->where(function ($q) use ($data_input) {
-                $phone1 = $data_input['cus_tel_1'] ?? null;
-                $phone2 = $data_input['cus_tel_2'] ?? null;
-                if ($phone1) {
-                    $q->where('cus_tel_1', $phone1)
-                      ->orWhere('cus_tel_2', $phone1);
-                }
-                if ($phone2) {
-                    $q->orWhere('cus_tel_1', $phone2)
-                      ->orWhere('cus_tel_2', $phone2);
-                }
-            })
-            ->orWhere('cus_email', $data_input['cus_email'] ?? null)
-            ->exists();
-
-        if ($duplicate) {
-            return response()->json([
-                'status' => 'error',
-                'message' => 'Duplicate phone number or email'
-            ], 422);
-        }
-
-        // Check for duplicate phone or email
+        // Check for duplicate phone number or email
         $duplicate = Customer::query()
             ->where(function ($q) use ($data_input) {
                 $phone1 = $data_input['cus_tel_1'] ?? null;

--- a/tnp-backend/routes/api.php
+++ b/tnp-backend/routes/api.php
@@ -69,6 +69,8 @@ Route::prefix('v1')->group(function() {
         'pricing' => PricingController::class,
     ]);
 
+    Route::get('/customers/check-duplicate', [CustomerController::class, 'checkDuplicate']);
+
 
     //---------- User Management ----------
     Route::controller(UserController::class)->group(function () {

--- a/tnp-frontend/src/features/Customer/customerApi.js
+++ b/tnp-frontend/src/features/Customer/customerApi.js
@@ -82,6 +82,20 @@ export const customerApi = createApi({
         method: "DELETE",
       }),
     }),
+    checkDuplicate: builder.query({
+      query: (payload) => {
+        const queryParams = {
+          tel: payload?.tel,
+          email: payload?.email,
+          exclude: payload?.exclude,
+        };
+        const queryString = qs.stringify(queryParams, { skipNulls: true });
+        return {
+          url: `/customers/check-duplicate?${queryString}`,
+          method: "GET",
+        };
+      },
+    }),
     updateRecall: builder.mutation({
       invalidatesTags: ["Customer"],
       query: (payload) => ({
@@ -108,4 +122,5 @@ export const {
   useDelCustomerMutation,
   useUpdateRecallMutation,
   useChangeGradeMutation,
+  useLazyCheckDuplicateQuery,
 } = customerApi;

--- a/tnp-frontend/src/pages/Customer/CustomerList.jsx
+++ b/tnp-frontend/src/pages/Customer/CustomerList.jsx
@@ -446,6 +446,8 @@ const SortInfoDisplay = ({ sortModel }) => {
 
 function CustomerList() {
   const user = JSON.parse(localStorage.getItem("userData"));
+  // Increment this value whenever the table column structure changes
+  const COLUMN_PREF_VERSION = 1;
   const [delCustomer] = useDelCustomerMutation();
   const [updateRecall] = useUpdateRecallMutation();
   const [updateCustomer] = useUpdateCustomerMutation();
@@ -605,8 +607,9 @@ function CustomerList() {
 
     // Store column visibility in localStorage for persistence between sessions
     try {
-      // Add timestamp to track when preferences were last updated
+      // Add timestamp and version to track preferences
       const columnPreferences = {
+        version: COLUMN_PREF_VERSION,
         model: newModel,
         timestamp: new Date().toISOString(),
         username: user?.username || "unknown",
@@ -627,8 +630,9 @@ function CustomerList() {
 
     // Store column order in localStorage for persistence between sessions
     try {
-      // Save the column order with metadata
+      // Save the column order with metadata and version
       const columnOrderPreferences = {
+        version: COLUMN_PREF_VERSION,
         order: newOrder,
         timestamp: new Date().toISOString(),
         username: user?.username || "unknown",
@@ -972,12 +976,10 @@ function CustomerList() {
       if (savedVisibilityPrefs) {
         const savedPrefs = JSON.parse(savedVisibilityPrefs);
 
-        // Check if we have the new format with metadata
-        const savedModel = savedPrefs.model || savedPrefs;
-
-        // Apply the saved visibility settings
-        setColumnVisibilityModel(savedModel);
-
+        if (savedPrefs.version === COLUMN_PREF_VERSION) {
+          const savedModel = savedPrefs.model || savedPrefs;
+          setColumnVisibilityModel(savedModel);
+        }
       }
 
       // Load column order settings
@@ -985,12 +987,10 @@ function CustomerList() {
       if (savedOrderPrefs) {
         const savedOrderData = JSON.parse(savedOrderPrefs);
 
-        // Check if we have the new format with metadata
-        const savedOrder = savedOrderData.order || savedOrderData;
-
-        // Apply the saved order settings
-        setColumnOrderModel(savedOrder);
-
+        if (savedOrderData.version === COLUMN_PREF_VERSION) {
+          const savedOrder = savedOrderData.order || savedOrderData;
+          setColumnOrderModel(savedOrder);
+        }
       }
     } catch (error) {
       console.warn("Failed to load saved column settings", error);

--- a/tnp-frontend/src/pages/Customer/CustomerList.jsx
+++ b/tnp-frontend/src/pages/Customer/CustomerList.jsx
@@ -811,15 +811,17 @@ function CustomerList() {
       open_dialog_loading();
 
       try {
-        const res = await delCustomer(params.cus_id);
+        const res = await delCustomer(params.cus_id).unwrap();
 
-        if (res.data.status === "success") {
+        if (res.status === "success") {
           open_dialog_ok_timer("ลบข้อมูลสำเร็จ");
+          // Reload data after deletion
+          refetch();
           // Scroll to top after deletion is successful
           scrollToTop();
         }
       } catch (error) {
-        open_dialog_error(error.message, error);
+        open_dialog_error(error.data?.message || error.message, error);
         console.error(error);
       }
     }
@@ -839,15 +841,17 @@ function CustomerList() {
       };
 
       try {
-        const res = await updateRecall(inputUpdate);
+        const res = await updateRecall(inputUpdate).unwrap();
 
-        if (res.data.status === "success") {
+        if (res.status === "success") {
           open_dialog_ok_timer("รีเซตเวลาสำเร็จ");
+          // Reload data after recall timer reset
+          refetch();
           // Scroll to top after recall timer reset is successful
           scrollToTop();
         }
       } catch (error) {
-        open_dialog_error(error.message, error);
+        open_dialog_error(error.data?.message || error.message, error);
         console.error(error);
       }
     }
@@ -1706,6 +1710,7 @@ function CustomerList() {
           openDialog={openDialog}
           handleCloseDialog={handleCloseDialog}
           handleRecall={handleRecall}
+          onSaved={refetch}
         />
 
         <TitleBar title="customer" />

--- a/tnp-frontend/src/pages/Customer/DialogForm.jsx
+++ b/tnp-frontend/src/pages/Customer/DialogForm.jsx
@@ -57,6 +57,7 @@ import {
 import {
   useAddCustomerMutation,
   useUpdateCustomerMutation,
+  useLazyCheckDuplicateQuery,
 } from "../../features/Customer/customerApi";
 import { setLocationSearch } from "../../features/globalSlice";
 import {
@@ -171,6 +172,7 @@ function DialogForm(props) {
   // API hooks
   const [addCustomer] = useAddCustomerMutation();
   const [updateCustomer] = useUpdateCustomerMutation();
+  const [checkDuplicate] = useLazyCheckDuplicateQuery();
   const {
     data: locations,
     error,
@@ -389,6 +391,19 @@ function DialogForm(props) {
       setSaveLoading(true);
 
       try {
+        // Check for duplicate phone or email before saving
+        const dupResp = await checkDuplicate({
+          tel: inputList.cus_tel_1,
+          email: inputList.cus_email,
+          exclude: mode === "edit" ? inputList.cus_id : undefined,
+        }).unwrap();
+
+        if (dupResp.exists) {
+          setSaveLoading(false);
+          open_dialog_error("พบเบอร์โทรหรืออีเมลซ้ำในระบบ");
+          return;
+        }
+
         open_dialog_loading();
 
         const res =

--- a/tnp-frontend/src/pages/Customer/DialogForm.jsx
+++ b/tnp-frontend/src/pages/Customer/DialogForm.jsx
@@ -408,10 +408,10 @@ function DialogForm(props) {
 
         const res =
           mode === "create"
-            ? await addCustomer(inputList)
-            : await updateCustomer(inputList);
+            ? await addCustomer(inputList).unwrap()
+            : await updateCustomer(inputList).unwrap();
 
-        if (res.data.status === "success") {
+        if (res.status === "success") {
           props.handleCloseDialog();
 
           open_dialog_ok_timer("บันทึกข้อมูลสำเร็จ").then((result) => {
@@ -421,12 +421,12 @@ function DialogForm(props) {
           });
         } else {
           setSaveLoading(false);
-          open_dialog_error(res.data.message);
-          console.error(res.data.message);
+          open_dialog_error(res.message);
+          console.error(res.message);
         }
       } catch (error) {
         setSaveLoading(false);
-        open_dialog_error(error.message, error);
+        open_dialog_error(error.data?.message || error.message, error);
         console.error(error);
       }
     }
@@ -706,22 +706,24 @@ function DialogForm(props) {
                           </FormHelperText>
                         </FormControl>
                         <Tooltip title="จัดการประเภทธุรกิจ">
-                          <IconButton
-                            color="primary"
-                            size="small"
-                            sx={{
-                              mt: 0.5,
-                              bgcolor: (theme) =>
-                                theme.vars.palette.grey.outlinedInput,
-                              border: "1px solid",
-                              borderColor: (theme) =>
-                                theme.vars.palette.grey.outlinedInput,
-                            }}
-                            disabled={mode === "view"}
-                            onClick={handleOpenBusinessTypeManager}
-                          >
-                            <MdSettings />
-                          </IconButton>
+                          <span>
+                            <IconButton
+                              color="primary"
+                              size="small"
+                              sx={{
+                                mt: 0.5,
+                                bgcolor: (theme) =>
+                                  theme.vars.palette.grey.outlinedInput,
+                                border: "1px solid",
+                                borderColor: (theme) =>
+                                  theme.vars.palette.grey.outlinedInput,
+                              }}
+                              disabled={mode === "view"}
+                              onClick={handleOpenBusinessTypeManager}
+                            >
+                              <MdSettings />
+                            </IconButton>
+                          </span>
                         </Tooltip>
                       </Box>
                     </Grid>

--- a/tnp-frontend/src/pages/Customer/DialogForm.jsx
+++ b/tnp-frontend/src/pages/Customer/DialogForm.jsx
@@ -391,16 +391,36 @@ function DialogForm(props) {
       setSaveLoading(true);
 
       try {
-        // Check for duplicate phone or email before saving
-        const dupResp = await checkDuplicate({
-          tel: inputList.cus_tel_1,
-          email: inputList.cus_email,
-          exclude: mode === "edit" ? inputList.cus_id : undefined,
-        }).unwrap();
+        // Check for duplicate phone numbers and email before saving
+        const duplicates = [];
 
-        if (dupResp.exists) {
+        if (inputList.cus_tel_1) {
+          const resp1 = await checkDuplicate({
+            tel: inputList.cus_tel_1,
+            exclude: mode === "edit" ? inputList.cus_id : undefined,
+          }).unwrap();
+          if (resp1.exists) duplicates.push("เบอร์โทร 1");
+        }
+
+        if (inputList.cus_tel_2) {
+          const resp2 = await checkDuplicate({
+            tel: inputList.cus_tel_2,
+            exclude: mode === "edit" ? inputList.cus_id : undefined,
+          }).unwrap();
+          if (resp2.exists) duplicates.push("เบอร์โทร 2");
+        }
+
+        if (inputList.cus_email) {
+          const resp3 = await checkDuplicate({
+            email: inputList.cus_email,
+            exclude: mode === "edit" ? inputList.cus_id : undefined,
+          }).unwrap();
+          if (resp3.exists) duplicates.push("อีเมล");
+        }
+
+        if (duplicates.length > 0) {
           setSaveLoading(false);
-          open_dialog_error("พบเบอร์โทรหรืออีเมลซ้ำในระบบ");
+          open_dialog_error(`พบข้อมูลซ้ำ: ${duplicates.join(", ")}`);
           return;
         }
 
@@ -413,6 +433,9 @@ function DialogForm(props) {
 
         if (res.status === "success") {
           props.handleCloseDialog();
+          if (props.onSaved) {
+            props.onSaved();
+          }
 
           open_dialog_ok_timer("บันทึกข้อมูลสำเร็จ").then((result) => {
             setSaveLoading(false);


### PR DESCRIPTION
## Summary
- version control customer table column state in localStorage
- expose `checkDuplicate` API from backend
- add RTK query hook for duplicate checking
- prevent saving duplicate phone or email in customer form

## Testing
- `vendor/bin/phpunit` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_68662cc119888328a2303be25f04277d