### PR TITLE
Implement stepper UX for customer form

### DIFF
--- a/tnp-frontend/src/pages/Customer/components/DialogForm/BasicInfoFields.jsx
+++ b/tnp-frontend/src/pages/Customer/components/DialogForm/BasicInfoFields.jsx
@@ -5,7 +5,7 @@ import { StyledTextField } from "./StyledComponents";
 function BasicInfoFields({ inputList, handleInputChange, errors, mode }) {
   return (
     <Grid container spacing={2}>
-      <Grid size={12} md={4}>
+      <Grid size={12} md={6}>
         <StyledTextField
           fullWidth
           required
@@ -20,7 +20,7 @@ function BasicInfoFields({ inputList, handleInputChange, errors, mode }) {
           InputProps={{ readOnly: mode === "view" }}
         />
       </Grid>
-      <Grid size={12} md={4}>
+      <Grid size={12} md={6}>
         <StyledTextField
           fullWidth
           required
@@ -35,7 +35,7 @@ function BasicInfoFields({ inputList, handleInputChange, errors, mode }) {
           InputProps={{ readOnly: mode === "view" }}
         />
       </Grid>
-      <Grid size={12} md={4}>
+      <Grid size={12} md={6}>
         <StyledTextField
           fullWidth
           required
@@ -50,7 +50,7 @@ function BasicInfoFields({ inputList, handleInputChange, errors, mode }) {
           InputProps={{ readOnly: mode === "view" }}
         />
       </Grid>
-      <Grid size={12}>
+      <Grid size={12} md={6}>
         <StyledTextField
           fullWidth
           label="ตำแหน่ง"


### PR DESCRIPTION
## Summary
- convert customer dialog to use MUI Stepper instead of tabs
- add step navigation with validation per step
- rearrange basic info fields layout for better spacing

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686650ec1734832892089b7dc4d68519