### PR TITLE
Add customer reducer and API tests

### DIFF
--- a/tnp-backend/tests/Feature/CustomerApiTest.php
+++ b/tnp-backend/tests/Feature/CustomerApiTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\MasterCustomer;
+use App\Models\MasterCustomerGroup;
+use App\Models\CustomerDetail;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Hash;
+
+class CustomerApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Use in-memory sqlite for testing
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+        $this->artisan('migrate');
+    }
+
+    public function test_can_fetch_customer_list()
+    {
+        // create user
+        $user = User::create([
+            'user_uuid' => (string) Str::uuid(),
+            'username' => 'tester',
+            'password' => 'secret',
+            'role' => 'admin',
+            'enable' => 'Y',
+            'user_is_enable' => true,
+            'deleted' => 0,
+            'user_is_deleted' => false,
+            'new_pass' => Hash::make('secret'),
+        ]);
+
+        // create customer group
+        $group = MasterCustomerGroup::create([
+            'mcg_name' => 'A',
+            'mcg_sort' => 1,
+            'mcg_is_use' => true,
+        ]);
+
+        // create customer
+        $customer = MasterCustomer::create([
+            'cus_id' => (string) Str::uuid(),
+            'cus_mcg_id' => $group->mcg_id,
+            'cus_no' => 'CUS001',
+            'cus_channel' => 1,
+            'cus_company' => 'Test Co',
+            'cus_firstname' => 'John',
+            'cus_lastname' => 'Doe',
+            'cus_name' => 'JD',
+            'cus_tel_1' => '1234567890',
+            'cus_manage_by' => $user->user_id,
+            'cus_is_use' => true,
+            'cus_created_date' => now(),
+        ]);
+
+        CustomerDetail::create([
+            'cd_id' => (string) Str::uuid(),
+            'cd_cus_id' => $customer->cus_id,
+            'cd_is_use' => true,
+            'cd_created_date' => now(),
+        ]);
+
+        $response = $this->getJson("/api/v1/customers?user={$user->user_id}");
+
+        $response->assertStatus(200)
+                 ->assertJsonStructure([
+                     'data',
+                     'groups',
+                     'total_count',
+                     'pagination'
+                 ]);
+    }
+}

--- a/tnp-frontend/package.json
+++ b/tnp-frontend/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -48,6 +49,7 @@
     "@vitejs/plugin-react": "^3.1.0",
     "rollup-plugin-visualizer": "^5.14.0",
     "source-map-explorer": "^2.5.3",
-    "vite": "^4.1.0"
+    "vite": "^4.1.0",
+    "vitest": "^0.34.1"
   }
 }

--- a/tnp-frontend/src/features/Customer/__tests__/customerReducers.test.js
+++ b/tnp-frontend/src/features/Customer/__tests__/customerReducers.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.stubGlobal('localStorage', {
+  getItem: vi.fn().mockReturnValue(null),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+  clear: vi.fn(),
+});
+
+const reducers = (await import('../customerReducers')).default;
+const initialState = (await import('../customerInitialState')).default;
+
+describe('customer reducers', () => {
+  it('setItemList updates itemList', () => {
+    const state = JSON.parse(JSON.stringify(initialState));
+    const payload = [{ id: 1, name: 'John' }];
+    reducers.setItemList(state, { payload });
+    expect(state.itemList).toEqual(payload);
+  });
+
+  it('resetInputList resets inputList to defaults', () => {
+    const state = JSON.parse(JSON.stringify(initialState));
+    state.inputList.cus_firstname = 'test';
+    reducers.resetInputList(state);
+    expect(state.inputList).toEqual(initialState.inputList);
+  });
+});


### PR DESCRIPTION
## Summary
- add Vitest setup and test script
- write customer reducer tests
- add backend Customer API feature test

## Testing
- `npx vitest run`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686928b404f88328a6561d14fdb70d66