### PR TITLE
Refactor customer utilities

### DIFF
--- a/tnp-backend/app/Http/Controllers/Api/V1/Customers/CustomerController.php
+++ b/tnp-backend/app/Http/Controllers/Api/V1/Customers/CustomerController.php
@@ -280,13 +280,8 @@ class CustomerController extends Controller
                 ->orderByDesc('cus_no')
                 ->first();
 
-            // Clean เบอร์โทรศัพท์ & Tax ID อัตโนมัติ
-            $fieldsToClean = ['cus_tel_1', 'cus_tel_2', 'cus_tax_id'];
-            array_walk($fieldsToClean, function ($field) use (&$data_input) {
-                if (isset($data_input[$field])) {
-                    $data_input[$field] = preg_replace('/[^0-9]/', '', $data_input[$field]);
-                }
-            });
+            // Clean phone numbers & tax ID
+            $this->customer_service->sanitizeNumbers($data_input);
 
             $customer->fill($data_input);
             $customer->cus_id = Str::uuid();
@@ -406,13 +401,8 @@ class CustomerController extends Controller
 
         $data_input = $request->all();
 
-        // Clean เบอร์โทรศัพท์ & Tax ID อัตโนมัติ
-        $fieldsToClean = ['cus_tel_1', 'cus_tel_2', 'cus_tax_id'];
-        array_walk($fieldsToClean, function ($field) use (&$data_input) {
-            if (isset($data_input[$field])) {
-                $data_input[$field] = preg_replace('/[^0-9]/', '', $data_input[$field]);
-            }
-        });
+        // Clean phone numbers & tax ID
+        $this->customer_service->sanitizeNumbers($data_input);
 
 
         try {

--- a/tnp-backend/app/Services/CustomerService.php
+++ b/tnp-backend/app/Services/CustomerService.php
@@ -38,6 +38,22 @@ class CustomerService
         return $datetime;
     }
 
+    /**
+     * Sanitize phone and tax ID fields by stripping non-digit characters.
+     *
+     * @param array $data    Input data array passed by reference.
+     * @param array $fields  List of keys to clean.
+     * @return void
+     */
+    public function sanitizeNumbers(array &$data, array $fields = ['cus_tel_1', 'cus_tel_2', 'cus_tax_id']): void
+    {
+        foreach ($fields as $field) {
+            if (isset($data[$field])) {
+                $data[$field] = preg_replace('/\D/', '', $data[$field]);
+            }
+        }
+    }
+
     // generate customer number
     public static function genCustomerNo(string $lastCustomerNumber = null): string
     {

--- a/tnp-backend/tests/Feature/CustomerApiTest.php
+++ b/tnp-backend/tests/Feature/CustomerApiTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\MasterCustomer;
+use App\Models\MasterCustomerGroup;
+use App\Models\CustomerDetail;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Hash;
+
+class CustomerApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Use in-memory sqlite for testing
+        config()->set('database.default', 'sqlite');
+        config()->set('database.connections.sqlite.database', ':memory:');
+        $this->artisan('migrate');
+    }
+
+    public function test_can_fetch_customer_list()
+    {
+        // create user
+        $user = User::create([
+            'user_uuid' => (string) Str::uuid(),
+            'username' => 'tester',
+            'password' => 'secret',
+            'role' => 'admin',
+            'enable' => 'Y',
+            'user_is_enable' => true,
+            'deleted' => 0,
+            'user_is_deleted' => false,
+            'new_pass' => Hash::make('secret'),
+        ]);
+
+        // create customer group
+        $group = MasterCustomerGroup::create([
+            'mcg_name' => 'A',
+            'mcg_sort' => 1,
+            'mcg_is_use' => true,
+        ]);
+
+        // create customer
+        $customer = MasterCustomer::create([
+            'cus_id' => (string) Str::uuid(),
+            'cus_mcg_id' => $group->mcg_id,
+            'cus_no' => 'CUS001',
+            'cus_channel' => 1,
+            'cus_company' => 'Test Co',
+            'cus_firstname' => 'John',
+            'cus_lastname' => 'Doe',
+            'cus_name' => 'JD',
+            'cus_tel_1' => '1234567890',
+            'cus_manage_by' => $user->user_id,
+            'cus_is_use' => true,
+            'cus_created_date' => now(),
+        ]);
+
+        CustomerDetail::create([
+            'cd_id' => (string) Str::uuid(),
+            'cd_cus_id' => $customer->cus_id,
+            'cd_is_use' => true,
+            'cd_created_date' => now(),
+        ]);
+
+        $response = $this->getJson("/api/v1/customers?user={$user->user_id}");
+
+        $response->assertStatus(200)
+                 ->assertJsonStructure([
+                     'data',
+                     'groups',
+                     'total_count',
+                     'pagination'
+                 ]);
+    }
+}

--- a/tnp-frontend/package.json
+++ b/tnp-frontend/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -48,6 +49,7 @@
     "@vitejs/plugin-react": "^3.1.0",
     "rollup-plugin-visualizer": "^5.14.0",
     "source-map-explorer": "^2.5.3",
-    "vite": "^4.1.0"
+    "vite": "^4.1.0",
+    "vitest": "^0.34.1"
   }
 }

--- a/tnp-frontend/src/features/Customer/__tests__/customerReducers.test.js
+++ b/tnp-frontend/src/features/Customer/__tests__/customerReducers.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.stubGlobal('localStorage', {
+  getItem: vi.fn().mockReturnValue(null),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+  clear: vi.fn(),
+});
+
+const reducers = (await import('../customerReducers')).default;
+const initialState = (await import('../customerInitialState')).default;
+
+describe('customer reducers', () => {
+  it('setItemList updates itemList', () => {
+    const state = JSON.parse(JSON.stringify(initialState));
+    const payload = [{ id: 1, name: 'John' }];
+    reducers.setItemList(state, { payload });
+    expect(state.itemList).toEqual(payload);
+  });
+
+  it('resetInputList resets inputList to defaults', () => {
+    const state = JSON.parse(JSON.stringify(initialState));
+    state.inputList.cus_firstname = 'test';
+    reducers.resetInputList(state);
+    expect(state.inputList).toEqual(initialState.inputList);
+  });
+});

--- a/tnp-frontend/src/features/Customer/customerUtils.js
+++ b/tnp-frontend/src/features/Customer/customerUtils.js
@@ -2,6 +2,7 @@ import moment from "moment";
 import dayjs from "dayjs";
 import "dayjs/locale/th";
 import relativeTime from "dayjs/plugin/relativeTime";
+export { genCustomerNo } from "../../utils/utilityFunction";
 
 // Setup dayjs plugins
 dayjs.extend(relativeTime);
@@ -86,18 +87,3 @@ export const formatRecallDays = (days) => {
   }
 };
 
-export function genCustomerNo(lastCustomerNumber = null) {
-  const currentYear = moment().year().toString();
-
-  let nextId;
-  if (lastCustomerNumber) {
-    const lastYear = lastCustomerNumber.substring(0, 4);
-    const lastId = parseInt(lastCustomerNumber.substring(4), 10);
-
-    nextId = lastYear === currentYear ? lastId + 1 : 1;
-  } else {
-    nextId = 1;
-  }
-
-  return `${currentYear}${nextId.toString().padStart(6, "0")}`;
-}

--- a/tnp-frontend/src/features/Pricing/pricingUtils.js
+++ b/tnp-frontend/src/features/Pricing/pricingUtils.js
@@ -13,22 +13,6 @@ export function formatCustomRelativeTime(dateString) {
   }
 }
 
-export function genCustomerNo(lastCustomerNumber = null)
-{
-  const currentYear = moment().year().toString();
-
-  let nextId;
-  if (lastCustomerNumber) {
-    const lastYear = lastCustomerNumber.substring(0, 4);
-    const lastId = parseInt(lastCustomerNumber.substring(4), 10);
-
-    nextId = lastYear === currentYear ? lastId + 1 : 1;
-  } else {
-    nextId = 1;
-  }
-
-  return `${currentYear}${nextId.toString().padStart(6, "0")}`;
-};
 
 export function validateValue(props) {
   let result = "";

--- a/tnp-frontend/src/features/UserManagement/customerUtils.js
+++ b/tnp-frontend/src/features/UserManagement/customerUtils.js
@@ -1,4 +1,5 @@
 import moment from "moment";
+export { genCustomerNo } from "../../utils/utilityFunction";
 
 // แปลงค่าวันที่ตามลูกค้า ให้อยู่ในรูปแบบนับเวลาถอยหลัง
 export function formatCustomRelativeTime(dateString) {
@@ -13,19 +14,3 @@ export function formatCustomRelativeTime(dateString) {
   }
 }
 
-export function genCustomerNo(lastCustomerNumber = null)
-{
-  const currentYear = moment().year().toString();
-
-  let nextId;
-  if (lastCustomerNumber) {
-    const lastYear = lastCustomerNumber.substring(0, 4);
-    const lastId = parseInt(lastCustomerNumber.substring(4), 10);
-
-    nextId = lastYear === currentYear ? lastId + 1 : 1;
-  } else {
-    nextId = 1;
-  }
-
-  return `${currentYear}${nextId.toString().padStart(6, "0")}`;
-};

--- a/tnp-frontend/src/pages/Customer/CustomerList.jsx
+++ b/tnp-frontend/src/pages/Customer/CustomerList.jsx
@@ -82,10 +82,7 @@ import FilterPanel from "./FilterPanel";
 import FilterTags from "./FilterTags";
 import ScrollContext from "./ScrollContext";
 import ScrollTopButton from "./ScrollTopButton";
-import {
-  formatCustomRelativeTime,
-  genCustomerNo,
-} from "../../features/Customer/customerUtils";
+import { formatCustomRelativeTime } from "../../features/Customer/customerUtils";
 import DialogForm from "./DialogForm";
 import { swal_delete_by_id } from "../../utils/dialog_swal2/dialog_delete_by_id";
 import {

--- a/tnp-frontend/src/utils/utilityFunction.js
+++ b/tnp-frontend/src/utils/utilityFunction.js
@@ -1,9 +1,28 @@
+import moment from "moment";
+
 // แปลงไฟล์เป็น Base64 สำหรับส่งผ่าน api แบบ json
-export function fileToBase64(file) { 
+export function fileToBase64(file) {
     return new Promise((resolve, reject) => {
       const reader = new FileReader();
       reader.onload = () => resolve(reader.result);
       reader.onerror = reject;
       reader.readAsDataURL(file);
     });
+}
+
+// Generate customer number in the format YYYY######
+export function genCustomerNo(lastCustomerNumber = null) {
+  const currentYear = moment().year().toString();
+
+  let nextId;
+  if (lastCustomerNumber) {
+    const lastYear = lastCustomerNumber.substring(0, 4);
+    const lastId = parseInt(lastCustomerNumber.substring(4), 10);
+
+    nextId = lastYear === currentYear ? lastId + 1 : 1;
+  } else {
+    nextId = 1;
+  }
+
+  return `${currentYear}${nextId.toString().padStart(6, "0")}`;
 }


### PR DESCRIPTION
## Summary
- centralize sanitizing of phone numbers and tax IDs in `CustomerService`
- use the new sanitizing method in `CustomerController`
- provide a single `genCustomerNo` helper for the frontend
- re-export `genCustomerNo` and clean up unused imports

## Testing
- `php artisan test` *(fails: php not installed)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68692c8610f483289630921edda9f6df