### PR TITLE
Fix recall for old customers

### DIFF
--- a/tnp-backend/app/Http/Controllers/Api/V1/Customers/CustomerController.php
+++ b/tnp-backend/app/Http/Controllers/Api/V1/Customers/CustomerController.php
@@ -503,7 +503,28 @@ class CustomerController extends Controller
                 ], 404);
             }
 
-            $customer_detail = CustomerDetail::findOrFail($id);
+            $customer_detail = CustomerDetail::find($id);
+
+            // If the provided id does not match a detail record, try locating by customer id
+            if (!$customer_detail && $request->has('cus_id')) {
+                $customer_detail = CustomerDetail::firstOrCreate(
+                    ['cd_cus_id' => $request->cus_id],
+                    [
+                        'cd_id' => (string) Str::uuid(),
+                        'cd_created_date' => now(),
+                        'cd_created_by' => Auth::id(),
+                        'cd_is_use' => true,
+                    ]
+                );
+            }
+
+            if (!$customer_detail) {
+                return response()->json([
+                    'status' => 'error',
+                    'message' => 'Customer detail not found.'
+                ], 404);
+            }
+
             $customer_detail->fill($update_input);
             $customer_detail->cd_last_datetime = $this->customer_service->setRecallDatetime($group_q->mcg_recall_default);
             $customer_detail->cd_updated_date = now();

--- a/tnp-frontend/src/pages/Customer/CustomerList.jsx
+++ b/tnp-frontend/src/pages/Customer/CustomerList.jsx
@@ -402,21 +402,22 @@ function CustomerList() {
       open_dialog_loading();
 
       const inputUpdate = {
+        cus_id: params.cus_id,
         cus_mcg_id: params.cus_mcg_id,
         cd_id: params.cd_id,
         cd_updated_by: user.user_id,
       };
 
       try {
-        const res = await updateRecall(inputUpdate);
+        const res = await updateRecall(inputUpdate).unwrap();
 
-        if (res.data.status === "success") {
+        if (res.status === "success") {
           open_dialog_ok_timer("รีเซตเวลาสำเร็จ");
           // Scroll to top after recall timer reset is successful
           scrollToTop();
         }
       } catch (error) {
-        open_dialog_error(error.message, error);
+        open_dialog_error(error.data?.message || error.message, error);
         console.error(error);
       }
     }


### PR DESCRIPTION
## Summary
- ensure recall endpoint creates missing detail record
- send customer id with recall requests and handle errors properly on the client

## Testing
- `php artisan test` *(fails: command not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b355d9cfc83289f33d0d70486bfee