### PR TITLE
Add MaxSupply feature skeleton

### DIFF
--- a/tnp-backend/app/Http/Controllers/Api/V1/MaxSupply/CalendarController.php
+++ b/tnp-backend/app/Http/Controllers/Api/V1/MaxSupply/CalendarController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\MaxSupply;
+
+use App\Http\Controllers\Controller;
+use App\Models\MaxSupply;
+use Illuminate\Http\Request;
+
+class CalendarController extends Controller
+{
+    public function index()
+    {
+        $events = MaxSupply::all()->map(function ($item) {
+            return [
+                'id' => $item->id,
+                'title' => $item->title,
+                'start' => $item->due_date,
+                'end' => $item->due_date,
+            ];
+        });
+
+        return response()->json($events);
+    }
+}

--- a/tnp-backend/app/Http/Controllers/Api/V1/MaxSupply/MaxSupplyController.php
+++ b/tnp-backend/app/Http/Controllers/Api/V1/MaxSupply/MaxSupplyController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\MaxSupply;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\MaxSupply\StoreMaxSupplyRequest;
+use App\Http\Requests\MaxSupply\UpdateMaxSupplyRequest;
+use App\Http\Resources\MaxSupply\MaxSupplyResource;
+use App\Models\MaxSupply;
+use App\Services\MaxSupplyService;
+use Illuminate\Http\Request;
+
+class MaxSupplyController extends Controller
+{
+    protected MaxSupplyService $service;
+
+    public function __construct()
+    {
+        $this->service = new MaxSupplyService();
+    }
+
+    public function index()
+    {
+        return MaxSupplyResource::collection(MaxSupply::all());
+    }
+
+    public function store(StoreMaxSupplyRequest $request)
+    {
+        $maxSupply = $this->service->create($request->validated());
+        return new MaxSupplyResource($maxSupply);
+    }
+
+    public function show(MaxSupply $maxSupply)
+    {
+        return new MaxSupplyResource($maxSupply);
+    }
+
+    public function update(UpdateMaxSupplyRequest $request, MaxSupply $maxSupply)
+    {
+        $maxSupply = $this->service->update($maxSupply, $request->validated());
+        return new MaxSupplyResource($maxSupply);
+    }
+
+    public function destroy(MaxSupply $maxSupply)
+    {
+        $maxSupply->delete();
+        return response()->noContent();
+    }
+
+    public function updateStatus(Request $request, MaxSupply $maxSupply)
+    {
+        $maxSupply->update(['status' => $request->input('status')]);
+        return new MaxSupplyResource($maxSupply);
+    }
+}

--- a/tnp-backend/app/Http/Controllers/Api/V1/MaxSupply/UploadController.php
+++ b/tnp-backend/app/Http/Controllers/Api/V1/MaxSupply/UploadController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\MaxSupply;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+
+class UploadController extends Controller
+{
+    public function store(Request $request)
+    {
+        if ($request->hasFile('file')) {
+            $path = $request->file('file')->store('max_supply');
+            return response()->json(['path' => $path]);
+        }
+
+        return response()->json(['message' => 'no file'], 400);
+    }
+}

--- a/tnp-backend/app/Http/Requests/MaxSupply/StoreMaxSupplyRequest.php
+++ b/tnp-backend/app/Http/Requests/MaxSupply/StoreMaxSupplyRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests\MaxSupply;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreMaxSupplyRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'worksheet_id' => 'required|integer',
+            'title' => 'required|string',
+            'due_date' => 'nullable|date',
+        ];
+    }
+}

--- a/tnp-backend/app/Http/Requests/MaxSupply/UpdateMaxSupplyRequest.php
+++ b/tnp-backend/app/Http/Requests/MaxSupply/UpdateMaxSupplyRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests\MaxSupply;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateMaxSupplyRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'worksheet_id' => 'sometimes|integer',
+            'title' => 'sometimes|string',
+            'status' => 'sometimes|string',
+            'due_date' => 'nullable|date',
+        ];
+    }
+}

--- a/tnp-backend/app/Http/Resources/MaxSupply/MaxSupplyResource.php
+++ b/tnp-backend/app/Http/Resources/MaxSupply/MaxSupplyResource.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Resources\MaxSupply;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class MaxSupplyResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     */
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'worksheet_id' => $this->worksheet_id,
+            'title' => $this->title,
+            'status' => $this->status,
+            'due_date' => $this->due_date,
+        ];
+    }
+}

--- a/tnp-backend/app/Models/MaxSupply.php
+++ b/tnp-backend/app/Models/MaxSupply.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class MaxSupply extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'worksheet_id',
+        'title',
+        'status',
+        'due_date',
+    ];
+}

--- a/tnp-backend/app/Services/MaxSupplyService.php
+++ b/tnp-backend/app/Services/MaxSupplyService.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\MaxSupply;
+
+class MaxSupplyService
+{
+    public function create(array $data): MaxSupply
+    {
+        return MaxSupply::create($data);
+    }
+
+    public function update(MaxSupply $maxSupply, array $data): MaxSupply
+    {
+        $maxSupply->update($data);
+        return $maxSupply;
+    }
+}

--- a/tnp-backend/database/migrations/2025_07_01_000001_create_max_supplies_table.php
+++ b/tnp-backend/database/migrations/2025_07_01_000001_create_max_supplies_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('max_supplies', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('worksheet_id')->nullable();
+            $table->string('title');
+            $table->string('status')->default('draft');
+            $table->date('due_date')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('max_supplies');
+    }
+};

--- a/tnp-backend/database/migrations/2025_07_01_000002_create_max_supply_logs_table.php
+++ b/tnp-backend/database/migrations/2025_07_01_000002_create_max_supply_logs_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('max_supply_logs', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('max_supply_id');
+            $table->string('action');
+            $table->json('payload')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('max_supply_logs');
+    }
+};

--- a/tnp-backend/database/migrations/2025_07_01_000003_create_max_supply_files_table.php
+++ b/tnp-backend/database/migrations/2025_07_01_000003_create_max_supply_files_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('max_supply_files', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('max_supply_id');
+            $table->string('path');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('max_supply_files');
+    }
+};

--- a/tnp-backend/routes/api.php
+++ b/tnp-backend/routes/api.php
@@ -17,6 +17,9 @@ use App\Http\Controllers\Api\V1\LocationController;
 use App\Http\Controllers\Api\V1\AuthController;
 use App\Http\Controllers\Api\V1\GlobalController;
 use App\Http\Controllers\Api\V1\Pricing\PricingController;
+use App\Http\Controllers\Api\V1\MaxSupply\CalendarController;
+use App\Http\Controllers\Api\V1\MaxSupply\MaxSupplyController;
+use App\Http\Controllers\Api\V1\MaxSupply\UploadController;
 use Laravel\Sanctum\Http\Controllers\CsrfCookieController;
 
 /*
@@ -150,5 +153,11 @@ Route::prefix('v1')->group(function() {
         Route::put('/business-types/{id}', 'update_business_type');
         Route::delete('/business-types/{id}', 'delete_business_type');
         Route::get('/get-status-by-type/{status_type}', 'get_status_by_type');
+
     });
+    //---------- Max Supply ----------
+    Route::apiResource("max-supply", MaxSupplyController::class);
+    Route::patch("max-supply/{id}/status", [MaxSupplyController::class, "updateStatus"]);
+    Route::get("max-supply/calendar", [CalendarController::class, "index"]);
+    Route::post("max-supply/upload", [UploadController::class, "store"]);
 });

--- a/tnp-frontend/src/features/MaxSupply/maxSupplyApi.js
+++ b/tnp-frontend/src/features/MaxSupply/maxSupplyApi.js
@@ -1,0 +1,81 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import axios from '../../api/axios';
+
+export const useMaxSupplies = () =>
+  useQuery({
+    queryKey: ['max-supplies'],
+    queryFn: async () => {
+      const { data } = await axios.get('/api/v1/max-supply');
+      return data;
+    }
+  });
+
+export const useMaxSupply = (id) =>
+  useQuery({
+    queryKey: ['max-supply', id],
+    enabled: !!id,
+    queryFn: async () => {
+      const { data } = await axios.get(`/api/v1/max-supply/${id}`);
+      return data;
+    }
+  });
+
+export const useCreateMaxSupply = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (payload) => {
+      const { data } = await axios.post('/api/v1/max-supply', payload);
+      return data;
+    },
+    onSuccess: () => qc.invalidateQueries(['max-supplies'])
+  });
+};
+
+export const useUpdateMaxSupply = (id) => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (payload) => {
+      const { data } = await axios.put(`/api/v1/max-supply/${id}`, payload);
+      return data;
+    },
+    onSuccess: () => qc.invalidateQueries(['max-supplies'])
+  });
+};
+
+export const useDeleteMaxSupply = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (id) => {
+      await axios.delete(`/api/v1/max-supply/${id}`);
+    },
+    onSuccess: () => qc.invalidateQueries(['max-supplies'])
+  });
+};
+
+export const useUpdateStatus = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, status }) => {
+      const { data } = await axios.patch(`/api/v1/max-supply/${id}/status`, { status });
+      return data;
+    },
+    onSuccess: () => qc.invalidateQueries(['max-supplies'])
+  });
+};
+
+export const useCalendar = () =>
+  useQuery({
+    queryKey: ['max-supply-calendar'],
+    queryFn: async () => {
+      const { data } = await axios.get('/api/v1/max-supply/calendar');
+      return data;
+    }
+  });
+
+export const useUploadFile = () =>
+  useMutation({
+    mutationFn: async (formData) => {
+      const { data } = await axios.post('/api/v1/max-supply/upload', formData);
+      return data;
+    }
+  });

--- a/tnp-frontend/src/features/MaxSupply/maxSupplySlice.js
+++ b/tnp-frontend/src/features/MaxSupply/maxSupplySlice.js
@@ -1,0 +1,12 @@
+import { create } from 'zustand';
+
+const useMaxSupplyStore = create((set) => ({
+  filter: '',
+  items: [],
+  selected: null,
+  setItems: (items) => set({ items }),
+  setSelected: (selected) => set({ selected }),
+  setFilter: (filter) => set({ filter }),
+}));
+
+export default useMaxSupplyStore;

--- a/tnp-frontend/src/features/MaxSupply/maxSupplyUtils.js
+++ b/tnp-frontend/src/features/MaxSupply/maxSupplyUtils.js
@@ -1,0 +1,4 @@
+export function calcPrintPoints(detail) {
+  if (!detail) return 0;
+  return detail.blocks ? detail.blocks.length : 0;
+}

--- a/tnp-frontend/src/pages/MaxSupply/AuditDialog.jsx
+++ b/tnp-frontend/src/pages/MaxSupply/AuditDialog.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Dialog } from '@mui/material';
+
+const AuditDialog = ({ open, onClose, logs = [] }) => (
+  <Dialog open={open} onClose={onClose}>
+    <div className="p-4">
+      <h2 className="text-xl mb-2">Audit Logs</h2>
+      <ul>
+        {logs.map((log) => (
+          <li key={log.id}>{log.action} - {log.created_at}</li>
+        ))}
+      </ul>
+    </div>
+  </Dialog>
+);
+
+export default AuditDialog;

--- a/tnp-frontend/src/pages/MaxSupply/FileUpload.jsx
+++ b/tnp-frontend/src/pages/MaxSupply/FileUpload.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { useDropzone } from 'react-dropzone';
+import { useUploadFile } from '../../features/MaxSupply/maxSupplyApi';
+
+const FileUpload = () => {
+  const upload = useUploadFile();
+
+  const onDrop = React.useCallback((acceptedFiles) => {
+    const formData = new FormData();
+    formData.append('file', acceptedFiles[0]);
+    upload.mutate(formData);
+  }, [upload]);
+
+  const { getRootProps, getInputProps } = useDropzone({ onDrop });
+
+  return (
+    <div {...getRootProps()} className="border p-4 rounded">
+      <input {...getInputProps()} />
+      <p>Drag and drop file here, or click to select</p>
+    </div>
+  );
+};
+
+export default FileUpload;

--- a/tnp-frontend/src/pages/MaxSupply/MaxSupplyCalendar.jsx
+++ b/tnp-frontend/src/pages/MaxSupply/MaxSupplyCalendar.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Calendar, momentLocalizer } from 'react-big-calendar';
+import moment from 'moment';
+import { useCalendar } from '../../features/MaxSupply/maxSupplyApi';
+
+const localizer = momentLocalizer(moment);
+
+const MaxSupplyCalendar = () => {
+  const { data } = useCalendar();
+
+  return (
+    <div style={{ height: 500 }}>
+      <Calendar
+        localizer={localizer}
+        events={data || []}
+        startAccessor="start"
+        endAccessor="end"
+      />
+    </div>
+  );
+};
+
+export default MaxSupplyCalendar;

--- a/tnp-frontend/src/pages/MaxSupply/MaxSupplyForm.jsx
+++ b/tnp-frontend/src/pages/MaxSupply/MaxSupplyForm.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { useCreateMaxSupply } from '../../features/MaxSupply/maxSupplyApi';
+import FileUpload from './FileUpload';
+
+const schema = z.object({
+  worksheet_id: z.string(),
+  title: z.string().min(1)
+});
+
+const MaxSupplyForm = () => {
+  const { register, handleSubmit, reset } = useForm({
+    resolver: zodResolver(schema)
+  });
+  const create = useCreateMaxSupply();
+
+  const onSubmit = (data) => {
+    create.mutate(data, { onSuccess: () => reset() });
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">
+      <input {...register('worksheet_id')} placeholder="Worksheet ID" className="border p-1" />
+      <input {...register('title')} placeholder="Title" className="border p-1" />
+      <FileUpload />
+      <button type="submit" className="px-2 py-1 bg-blue-500 text-white">Save</button>
+    </form>
+  );
+};
+
+export default MaxSupplyForm;

--- a/tnp-frontend/src/pages/MaxSupply/MaxSupplyList.jsx
+++ b/tnp-frontend/src/pages/MaxSupply/MaxSupplyList.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { useMaxSupplies } from '../../features/MaxSupply/maxSupplyApi';
+import useMaxSupplyStore from '../../features/MaxSupply/maxSupplySlice';
+
+const MaxSupplyList = () => {
+  const { data, isLoading } = useMaxSupplies();
+  const setSelected = useMaxSupplyStore((s) => s.setSelected);
+
+  if (isLoading) return <div>Loading...</div>;
+
+  return (
+    <div>
+      <h2 className="text-xl mb-2">Max Supply</h2>
+      <ul>
+        {data?.map((item) => (
+          <li key={item.id} onClick={() => setSelected(item)} className="cursor-pointer">
+            {item.title}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default MaxSupplyList;


### PR DESCRIPTION
## Summary
- scaffold backend files for MaxSupply module
- define migrations, model, controllers, requests and resources
- register new routes for MaxSupply API endpoints
- add frontend skeleton with tanstack-query and zustand
- provide basic pages and components for MaxSupply management

## Testing
- `php artisan test` *(fails: `php` not found)*
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b4e9060008328a1204e7c53bb6a15