### PR TITLE
Fix MUI date pickers missing LocalizationProvider

### DIFF
--- a/tnp-frontend/src/pages/MaxSupply/MaxSupplyForm.jsx
+++ b/tnp-frontend/src/pages/MaxSupply/MaxSupplyForm.jsx
@@ -27,6 +27,8 @@ import {
   useMediaQuery
 } from '@mui/material';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { useMaxSupply } from '../../context/MaxSupplyContext';
 import { useNavigate, useParams } from 'react-router-dom';
 import dayjs from 'dayjs';
@@ -909,8 +911,9 @@ const MaxSupplyForm = () => {
   };
   
   return (
-    <Box sx={{ p: isMobile ? 1 : 3 }}>
-      <Grid container spacing={2}>
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
+      <Box sx={{ p: isMobile ? 1 : 3 }}>
+        <Grid container spacing={2}>
         <Grid item xs={12}>
           <Paper sx={{ p: 2, mb: 2 }}>
             <Box sx={{ display: 'flex', alignItems: 'center' }}>
@@ -996,6 +999,7 @@ const MaxSupplyForm = () => {
         </Grid>
       </Grid>
     </Box>
+    </LocalizationProvider>
   );
 };
 

--- a/tnp-frontend/src/pages/MaxSupply/MaxSupplyList.jsx
+++ b/tnp-frontend/src/pages/MaxSupply/MaxSupplyList.jsx
@@ -28,6 +28,8 @@ import {
   useMediaQuery
 } from '@mui/material';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { useMaxSupply } from '../../context/MaxSupplyContext';
 import { useNavigate } from 'react-router-dom';
 import { 
@@ -557,41 +559,45 @@ const MaxSupplyList = () => {
                 </Select>
               </FormControl>
               
-              <DatePicker 
-                label="ตั้งแต่วันที่"
-                value={startDate}
-                onChange={setStartDate}
-                slotProps={{
-                  textField: {
-                    size: 'small',
-                    InputProps: {
-                      startAdornment: (
-                        <InputAdornment position="start">
-                          <FaCalendarAlt />
-                        </InputAdornment>
-                      )
+              <LocalizationProvider dateAdapter={AdapterDayjs}>
+                <DatePicker
+                  label="ตั้งแต่วันที่"
+                  value={startDate}
+                  onChange={setStartDate}
+                  slotProps={{
+                    textField: {
+                      size: 'small',
+                      InputProps: {
+                        startAdornment: (
+                          <InputAdornment position="start">
+                            <FaCalendarAlt />
+                          </InputAdornment>
+                        )
+                      }
                     }
-                  }
-                }}
-              />
+                  }}
+                />
+              </LocalizationProvider>
               
-              <DatePicker 
-                label="ถึงวันที่"
-                value={endDate}
-                onChange={setEndDate}
-                slotProps={{
-                  textField: {
-                    size: 'small',
-                    InputProps: {
-                      startAdornment: (
-                        <InputAdornment position="start">
-                          <FaCalendarAlt />
-                        </InputAdornment>
-                      )
+              <LocalizationProvider dateAdapter={AdapterDayjs}>
+                <DatePicker
+                  label="ถึงวันที่"
+                  value={endDate}
+                  onChange={setEndDate}
+                  slotProps={{
+                    textField: {
+                      size: 'small',
+                      InputProps: {
+                        startAdornment: (
+                          <InputAdornment position="start">
+                            <FaCalendarAlt />
+                          </InputAdornment>
+                        )
+                      }
                     }
-                  }
-                }}
-              />
+                  }}
+                />
+              </LocalizationProvider>
               
               <Box sx={{ ml: 'auto', display: 'flex', gap: 1 }}>
                 <Button 


### PR DESCRIPTION
## Summary
- wrap max supply list and form with `LocalizationProvider`
- use `AdapterDayjs` so date pickers have context

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686df72ae0788328903297db9e2eb442