### PR TITLE
Fix missing MUI icons and API configuration

### DIFF
--- a/tnp-frontend/package-lock.json
+++ b/tnp-frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
         "@ionic/react": "^7.1.3",
+        "@mui/icons-material": "^6.3.0",
         "@mui/material": "^6.3.0",
         "@mui/system": "^6.3.0",
         "@mui/x-data-grid": "^7.25.0",
@@ -1040,6 +1041,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-6.3.0.tgz",
+      "integrity": "sha512-3uWws6DveDn5KxCS34p+sUNMxehuclQY6OmoJeJJ+Sfg9L7LGBpksY/nX5ywKAqickTZnn+sQyVcp963ep9jvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/material": "^6.3.0",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/material": {

--- a/tnp-frontend/package.json
+++ b/tnp-frontend/package.json
@@ -16,6 +16,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@ionic/react": "^7.1.3",
+    "@mui/icons-material": "^6.3.0",
     "@mui/material": "^6.3.0",
     "@mui/system": "^6.3.0",
     "@mui/x-data-grid": "^7.25.0",

--- a/tnp-frontend/src/services/maxSupplyApi.js
+++ b/tnp-frontend/src/services/maxSupplyApi.js
@@ -1,6 +1,8 @@
 import axios from 'axios';
 
-const API_BASE_URL = '/api/v1';
+// Allow overriding the API base URL via environment variable for development
+const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL || '/api/v1';
 
 // Create axios instance with default config
 const api = axios.create({

--- a/tnp-frontend/vite.config.js
+++ b/tnp-frontend/vite.config.js
@@ -5,5 +5,13 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [
     react()
-  ]
+  ],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+      }
+    }
+  }
 })


### PR DESCRIPTION
## Summary
- add `@mui/icons-material` to front-end dependencies
- allow API base URL override via `VITE_API_BASE_URL`
- configure Vite dev server to proxy `/api` requests to backend

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686f63272a7483288dd4335320163e29