### PR TITLE
Fix MaxSupply form auto-fill

### DIFF
--- a/tnp-frontend/src/pages/MaxSupply/MaxSupplyForm.jsx
+++ b/tnp-frontend/src/pages/MaxSupply/MaxSupplyForm.jsx
@@ -114,6 +114,22 @@ const MaxSupplyForm = () => {
   const [worksheetOptions, setWorksheetOptions] = useState([]);
   const [autoFillPreview, setAutoFillPreview] = useState(null);
 
+  // Prefill data when navigated from worksheet list
+  useEffect(() => {
+    if (!isEditMode && location.state?.autoFillData) {
+      const data = location.state.autoFillData;
+      setFormData(prev => ({
+        ...prev,
+        ...data,
+        start_date: data.start_date ? dayjs(data.start_date) : prev.start_date,
+        expected_completion_date: data.expected_completion_date ? dayjs(data.expected_completion_date) : prev.expected_completion_date,
+        due_date: data.due_date ? dayjs(data.due_date) : prev.due_date,
+      }));
+      setSelectedWorksheet(location.state.worksheet || null);
+      setAutoFillPreview(data);
+    }
+  }, [location.state, isEditMode]);
+
   // Get worksheets data
   const { data: worksheetData, isLoading: worksheetLoading } = useGetAllWorksheetQuery();
 


### PR DESCRIPTION
## Summary
- prefill MaxSupply form fields when navigating from a worksheet

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68706351a200832896f00e3557129b8f