### PR TITLE
Use new worksheets for MaxSupply auto‑fill

### DIFF
--- a/tnp-backend/app/Http/Controllers/Api/V1/Worksheet/WorksheetController.php
+++ b/tnp-backend/app/Http/Controllers/Api/V1/Worksheet/WorksheetController.php
@@ -839,7 +839,7 @@ class WorksheetController extends Controller
             $worksheets = $this->worksheetService->getFromNewWorksNet();
             return response()->json([
                 'status' => 'success',
-                'data' => $worksheets
+                'data' => WorksheetResource::collection($worksheets)
             ]);
         } catch (\Exception $e) {
             Log::error('getFromNewWorksNet error : ' . $e);

--- a/tnp-backend/app/Http/Resources/V1/Worksheet/WorksheetResource.php
+++ b/tnp-backend/app/Http/Resources/V1/Worksheet/WorksheetResource.php
@@ -33,6 +33,10 @@ class WorksheetResource extends JsonResource
         $pattern_sizes_r = $worksheetService->filterShirtPatternByType($shirt_sizes_data, $this->pattern_id, $this->worksheet_id);
 
         $data = [
+            'code' => $this->work_id,
+            'customer_name' => optional($this->customer)->cus_name ?? '',
+            'product_name' => $this->work_name,
+            'special_instructions' => $this->worksheet_note ?? '',
             'worksheet_id' => $this->worksheet_id,
             'work_id' => $this->work_id,
             'work_name' => $this->work_name,

--- a/tnp-backend/app/Services/WorksheetService.php
+++ b/tnp-backend/app/Services/WorksheetService.php
@@ -396,7 +396,17 @@ class WorksheetService
      */
     public function getFromNewWorksNet()
     {
-        return Worksheet::where('nws_is_deleted', false)
+        return Worksheet::with([
+                'customer',
+                'fabric.fabricCustoms',
+                'shirtPattern.shirtSizes',
+                'shirtScreen',
+                'exampleQty',
+                'poloDetail.poloEmbroiders',
+                'nwsCreatedBy',
+                'user',
+            ])
+            ->where('nws_is_deleted', false)
             ->orderByDesc('nws_created_date')
             ->get();
     }

--- a/tnp-frontend/src/pages/MaxSupply/WorksheetList.jsx
+++ b/tnp-frontend/src/pages/MaxSupply/WorksheetList.jsx
@@ -157,28 +157,32 @@ const WorksheetList = () => {
 
   // Generate auto-fill preview
   const generateAutoFillPreview = (worksheet) => {
-    const items = worksheet.worksheet_items || [];
-    const totalQuantity = items.reduce((sum, item) => sum + (item.quantity || 0), 0);
-    
-    // Calculate production points
-    const screenPoints = calculatePoints(items, 'screen');
-    const dtfPoints = calculatePoints(items, 'dtf');
-    const sublimationPoints = calculatePoints(items, 'sublimation');
-    
+    const sizes = {};
+    if (Array.isArray(worksheet.pattern_sizes)) {
+      worksheet.pattern_sizes.forEach(s => {
+        sizes[s.size_name] = s.quantity || 0;
+      });
+    } else if (worksheet.pattern_sizes) {
+      const arr = [...(worksheet.pattern_sizes.men || []), ...(worksheet.pattern_sizes.women || []), ...(worksheet.pattern_sizes.unisex || [])];
+      arr.forEach(s => {
+        sizes[s.size_name] = s.quantity || 0;
+      });
+    }
+
     return {
       worksheet_id: worksheet.worksheet_id,
-      title: worksheet.product_name || `งานผลิต ${worksheet.code}`,
-      customer_name: worksheet.customer_name,
-      production_type: items[0]?.print_type || 'screen',
+      title: worksheet.product_name || worksheet.work_name,
+      customer_name: worksheet.customer_name || worksheet.cus_name,
+      production_type: worksheet.screen_dft > 0 ? 'dtf' : 'screen',
       due_date: worksheet.due_date,
-      shirt_type: items[0]?.shirt_type || 'polo',
-      total_quantity: totalQuantity,
-      sizes: items[0]?.sizes || [],
-      screen_points: screenPoints,
-      dtf_points: dtfPoints,
-      sublimation_points: sublimationPoints,
-      special_instructions: worksheet.special_instructions || '',
-      items: items,
+      shirt_type: worksheet.type_shirt === 'polo-shirt' ? 'polo' : 't-shirt',
+      total_quantity: worksheet.total_quantity,
+      sizes: sizes,
+      screen_points: worksheet.screen_point || 0,
+      dtf_points: worksheet.screen_dft || 0,
+      sublimation_points: 0,
+      special_instructions: worksheet.special_instructions || worksheet.worksheet_note || '',
+      items: [],
     };
   };
 

--- a/tnp-frontend/src/services/maxSupplyApi.js
+++ b/tnp-frontend/src/services/maxSupplyApi.js
@@ -185,105 +185,21 @@ export const worksheetApi = {
   },
 
   // Get worksheets for MaxSupply creation
-  getForMaxSupply: async (params = {}) => {
+  getForMaxSupply: async () => {
     try {
-      console.log("Fetching worksheets for MaxSupply with params:", params);
-      
-      // Construct query parameters
-      const queryParams = new URLSearchParams();
-      Object.keys(params).forEach(key => {
-        if (params[key] !== undefined && params[key] !== null && params[key] !== '') {
-          queryParams.append(key, params[key]);
-        }
-      });
-      
-      // Add required filter parameters for approved worksheets without existing production
-      if (!queryParams.has('status')) {
-        queryParams.append('status', 'approved');
+      const response = await api.get('/worksheets-newworksnet');
+      if (response.data && response.data.status === "success") {
+        return { status: "success", data: response.data.data };
       }
-      queryParams.append('has_production', 'false');
-      
-      // Build URL with query parameters
-      let url = '/worksheets';
-      const queryString = queryParams.toString();
-      if (queryString) {
-        url += `?${queryString}`;
-      }
-      
-      // Import the debug utility for API requests
-      const { debugApiRequest, debugApiResponse, debugWorksheetResponse } = await import('../utils/tokenDebug');
-      
-      // Debug API request before making it
-      debugApiRequest(url, {
-        headers: {
-          'Authorization': `Bearer ${localStorage.getItem('authToken') || localStorage.getItem('token')}`,
-          'Content-Type': 'application/json',
-          'Accept': 'application/json'
-        }
-      });
-      
-      console.log("Final URL for worksheet API request:", API_BASE_URL + url);
-      
-      // Try a direct fetch approach as a test
-      const token = localStorage.getItem('authToken') || localStorage.getItem('token');
-      try {
-        console.log("Attempting direct fetch as a test...");
-        const directFetchResponse = await fetch(`${API_BASE_URL}${url}`, {
-          method: 'GET',
-          headers: {
-            'Authorization': `Bearer ${token}`,
-            'Content-Type': 'application/json',
-            'Accept': 'application/json'
-          }
-        });
-        
-        const directData = await directFetchResponse.json();
-        console.log("Direct fetch response:", directData);
-        
-        // Debug the direct fetch response structure
-        debugWorksheetResponse(directData);
-        
-        // If direct fetch succeeds, try to normalize the response format
-        if (directData && Array.isArray(directData)) {
-          return { status: 'success', data: directData };
-        }
-      } catch (fetchError) {
-        console.error("Direct fetch test failed:", fetchError);
-      }
-      
-      // Proceed with axios request
-      const response = await api.get(url);
-      debugApiResponse(response, 'Worksheet API Response');
-      debugWorksheetResponse(response.data);
-      
-      // Special handling for this API which returns data directly
-      // The backend response may be an array directly in response.data without the wrapper object
-      if (response.data && Array.isArray(response.data)) {
-        console.log("API returned array directly in data property");
-        return { status: 'success', data: response.data };
-      } 
-      // Standard format with status and data fields
-      else if (response.data && response.data.status === 'success') {
-        return response.data;
-      }
-      // Handle other valid formats where data is directly available
-      else if (response.data && Array.isArray(response.data.data)) {
-        console.log("API returned standard format with data array");
-        return { status: 'success', data: response.data.data };
-      } else {
-        console.error("Invalid response format from worksheets API:", response.data);
-        return { status: 'error', message: 'Invalid response format', data: [] };
-      }
+      return { status: "error", message: "Invalid response", data: [] };
     } catch (error) {
-      console.error("Error fetching worksheets:", error);
+      console.error("Error fetching worksheets for MaxSupply:", error);
       if (error.response) {
-        console.error("Response status:", error.response.status);
-        console.error("Response data:", error.response.data);
+        return { status: "error", message: error.response.data?.message || "Request failed", data: [] };
       }
-      return { status: 'error', message: error.message, data: [] };
+      return { status: "error", message: error.message, data: [] };
     }
   },
-
   // Fetch worksheets directly from the NewWorksNet system
   getFromNewWorksNet: async () => {
     try {


### PR DESCRIPTION
## Summary
- pull worksheet data with relations for MaxSupply
- expose code/customer/product fields on worksheet resource
- return worksheet resource collection from `getFromNewWorksNet`
- fetch worksheets from new endpoint in MaxSupply frontend
- build auto‑fill preview using new worksheet format

## Testing
- `composer install`
- `php artisan test` *(fails: No application encryption key)*
- `npm install --legacy-peer-deps`

------
https://chatgpt.com/codex/tasks/task_e_687079bb3774832896705422a8f44e2a