### PR TITLE
Fix calendar timeline position

### DIFF
--- a/tnp-frontend/src/pages/MaxSupply/MaxSupplyCalendar.jsx
+++ b/tnp-frontend/src/pages/MaxSupply/MaxSupplyCalendar.jsx
@@ -369,8 +369,8 @@ const MaxSupplyCalendar = () => {
           onClick={() => handleEventClick(event)}
           sx={{
             position: 'absolute',
-            left: `${(timeline.startCol / 7) * 100}%`,
-            width: `${(timeline.width / 7) * 100}%`,
+            left: `${ (timeline.startCol / days.length) * 100}%`,
+            width: `${ (timeline.width / days.length) * 100}%`,
             height: 24,
             top: rowIndex * 28,
             backgroundColor: bgColor,
@@ -520,8 +520,8 @@ const MaxSupplyCalendar = () => {
                   key={`${rowIndex}-${timelineIndex}`}
                   sx={{
                     position: 'absolute',
-                    left: `${(timeline.startCol / 7) * 100}%`,
-                    width: `${(timeline.width / 7) * 100}%`,
+                    left: `${ (timeline.startCol / days.length) * 100}%`,
+                    width: `${ (timeline.width / days.length) * 100}%`,
                     top: 40 + rowIndex * 28,
                     height: 24,
                     pointerEvents: 'auto',

--- a/tnp-frontend/src/pages/MaxSupply/components/CalendarView.jsx
+++ b/tnp-frontend/src/pages/MaxSupply/components/CalendarView.jsx
@@ -229,8 +229,8 @@ const EnhancedCalendarView = ({
         startCol: actualStart,
         width,
         duration,
-        leftPercent: `${(actualStart / 7) * 100}%`,
-        widthPercent: `${(width / 7) * 100}%`
+        leftPercent: `${(actualStart / calendarDays.length) * 100}%`,
+        widthPercent: `${(width / calendarDays.length) * 100}%`
       });
       console.log('=== END TIMELINE CALCULATION ===');
 
@@ -469,8 +469,8 @@ const EnhancedCalendarView = ({
           onMouseLeave={() => setHoveredTimeline(null)}
           sx={{
             position: 'absolute',
-            left: `${(timeline.startCol / 7) * 100}%`,
-            width: `${Math.max((timeline.width / 7) * 100, 8)}%`, // Minimum 8% width for visibility
+            left: `${ (timeline.startCol / calendarDays.length) * 100}%`,
+            width: `${Math.max( (timeline.width / calendarDays.length) * 100, 8)}%`, // Minimum 8% width for visibility
             height: isMobile ? 18 : 22,
             top: (isMobile ? 45 : 65) + rowIndex * (isMobile ? 22 : 26),
             cursor: 'pointer',
@@ -970,8 +970,8 @@ const EnhancedCalendarView = ({
     
          eventRows.forEach((row, rowIndex) => {
        console.log(`Row ${rowIndex}:`, row.map(timeline => {
-         const leftPercent = (timeline.startCol / 7) * 100;
-         const widthPercent = (timeline.width / 7) * 100;
+         const leftPercent =  (timeline.startCol / calendarDays.length) * 100;
+         const widthPercent =  (timeline.width / calendarDays.length) * 100;
          return {
            eventId: timeline.event.id,
            title: timeline.event.title || timeline.event.customer_name,


### PR DESCRIPTION
## Summary
- align timeline bars with month grid by using total days in range

## Testing
- `composer install`
- `./vendor/bin/phpunit --stop-on-failure` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6871fe51fae48328b8928d6ee2a71c6a