### PR TITLE
Implement GPS address formatting

### DIFF
--- a/tnp-frontend/src/pages/Customer/components/BusinessDetailStep/useGpsHelper.js
+++ b/tnp-frontend/src/pages/Customer/components/BusinessDetailStep/useGpsHelper.js
@@ -403,9 +403,11 @@ export const useGpsHelper = (inputList) => {
     try {
       const fullAddress = [
         addressData.address,
-        addressData.subdistrict,
-        addressData.district,
-        addressData.province,
+        addressData.subdistrict
+          ? `ต.${addressData.subdistrict}`
+          : "",
+        addressData.district ? `อ.${addressData.district}` : "",
+        addressData.province ? `จ.${addressData.province}` : "",
         addressData.zipCode,
       ]
         .filter(Boolean)


### PR DESCRIPTION
## Summary
- update GPS autofill to prepend Thai address prefixes when constructing the full address

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687dfa08907883288e38c226a038450a