### PR TITLE
refactor: centralize quotation styles

### DIFF
--- a/tnp-frontend/src/pages/Accounting/PricingIntegration/components/CreateQuotationForm.jsx
+++ b/tnp-frontend/src/pages/Accounting/PricingIntegration/components/CreateQuotationForm.jsx
@@ -2,11 +2,9 @@ import React, { useState, useEffect } from 'react';
 import {
     Box,
     Container,
-    Paper,
     Typography,
     Grid,
     TextField,
-    Button,
     Card,
     CardContent,
     Divider,
@@ -44,75 +42,16 @@ import {
     Print as PrintIcon,
 } from '@mui/icons-material';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
-import { styled } from '@mui/material/styles';
 import PricingRequestNotesButton from './PricingRequestNotesButton';
 import QuotationPreview from './QuotationPreview';
 import CustomerEditCard from './CustomerEditCard';
-
-// Styled Components with our theme colors
-const StyledPaper = styled(Paper)(({ theme }) => ({
-    background: 'linear-gradient(135deg, #FFFFFF 0%, #F8F9FA 100%)',
-    borderRadius: '16px',
-    boxShadow: '0 8px 32px rgba(144, 15, 15, 0.08)',
-    border: '1px solid rgba(144, 15, 15, 0.1)',
-    overflow: 'hidden',
-}));
-
-const SectionHeader = styled(Box)(({ theme }) => ({
-    background: 'linear-gradient(135deg, #900F0F 0%, #B20000 100%)',
-    color: '#FFFFFF',
-    padding: '16px 24px',
-    margin: '-1px -1px 24px -1px',
-    borderRadius: '16px 16px 0 0',
-    display: 'flex',
-    alignItems: 'center',
-    gap: '12px',
-}));
-
-const InfoCard = styled(Card)(({ theme }) => ({
-    backgroundColor: '#F8F9FA',
-    border: '1px solid #E36264',
-    borderRadius: '12px',
-    '& .MuiCardContent-root': {
-        padding: '20px',
-        '&:last-child': {
-            paddingBottom: '20px',
-        },
-    },
-}));
-
-const PrimaryButton = styled(Button)(({ theme }) => ({
-    background: 'linear-gradient(135deg, #900F0F 0%, #B20000 100%)',
-    color: '#FFFFFF',
-    borderRadius: '12px',
-    padding: '12px 24px',
-    fontSize: '16px',
-    fontWeight: 600,
-    textTransform: 'none',
-    boxShadow: '0 4px 16px rgba(144, 15, 15, 0.3)',
-    '&:hover': {
-        background: 'linear-gradient(135deg, #B20000 0%, #E36264 100%)',
-        transform: 'translateY(-2px)',
-        boxShadow: '0 8px 24px rgba(144, 15, 15, 0.4)',
-    },
-    transition: 'all 0.3s ease-in-out',
-}));
-
-const SecondaryButton = styled(Button)(({ theme }) => ({
-    border: '2px solid #B20000',
-    color: '#B20000',
-    borderRadius: '12px',
-    padding: '10px 24px',
-    fontSize: '16px',
-    fontWeight: 600,
-    textTransform: 'none',
-    '&:hover': {
-        backgroundColor: 'rgba(178, 0, 0, 0.05)',
-        border: '2px solid #900F0F',
-        color: '#900F0F',
-    },
-    transition: 'all 0.3s ease-in-out',
-}));
+import {
+    StyledPaper,
+    SectionHeader,
+    InfoCard,
+    PrimaryButton,
+    SecondaryButton,
+} from './styles/QuotationStyles';
 
 const Transition = React.forwardRef(function Transition(props, ref) {
     return <Slide direction="up" ref={ref} {...props} />;

--- a/tnp-frontend/src/pages/Accounting/PricingIntegration/components/CreateQuotationModal.jsx
+++ b/tnp-frontend/src/pages/Accounting/PricingIntegration/components/CreateQuotationModal.jsx
@@ -2,20 +2,15 @@ import React, { useState, useEffect } from 'react';
 import {
     Box,
     Grid,
-    Card,
     CardContent,
     Typography,
-    Button,
     TextField,
     Chip,
-    Dialog,
-    DialogTitle,
     DialogContent,
     DialogActions,
     Alert,
     Skeleton,
     Stack,
-    Paper,
     Checkbox,
     Avatar,
     Fade,
@@ -35,89 +30,14 @@ import {
     Add as AddIcon,
     Remove as RemoveIcon,
 } from '@mui/icons-material';
-import { styled } from '@mui/material/styles';
-
-// Styled Components
-const StyledDialog = styled(Dialog)(({ theme }) => ({
-    '& .MuiDialog-paper': {
-        borderRadius: '16px',
-        maxWidth: '1000px',
-        width: '90vw',
-        maxHeight: '90vh',
-        background: 'linear-gradient(135deg, #FFFFFF 0%, #F8F9FA 100%)',
-        boxShadow: '0 24px 48px rgba(144, 15, 15, 0.15)',
-    },
-}));
-
-const StyledDialogTitle = styled(DialogTitle)(({ theme }) => ({
-    background: 'linear-gradient(135deg, #900F0F 0%, #B20000 100%)',
-    color: '#FFFFFF',
-    padding: '24px 32px',
-    position: 'relative',
-    '& .MuiTypography-root': {
-        fontSize: '1.5rem',
-        fontWeight: 600,
-    },
-}));
-
-const SelectionCard = styled(Card)(({ theme, selected }) => ({
-    cursor: 'pointer',
-    transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
-    border: selected ? '2px solid #900F0F' : '1px solid #E5E7EB',
-    backgroundColor: selected ? 'rgba(144, 15, 15, 0.02)' : '#FFFFFF',
-    transform: selected ? 'translateY(-2px)' : 'translateY(0)',
-    boxShadow: selected 
-        ? '0 8px 25px rgba(144, 15, 15, 0.15)' 
-        : '0 2px 8px rgba(0, 0, 0, 0.08)',
-    '&:hover': {
-        transform: 'translateY(-4px)',
-        boxShadow: '0 12px 32px rgba(144, 15, 15, 0.2)',
-        borderColor: selected ? '#900F0F' : '#B20000',
-    },
-}));
-
-const CustomerInfoCard = styled(Paper)(({ theme }) => ({
-    background: 'linear-gradient(135deg, #F8F9FA 0%, #FFFFFF 100%)',
-    border: '1px solid #E36264',
-    borderRadius: '12px',
-    padding: '20px',
-    marginBottom: '24px',
-    position: 'relative',
-    '&::before': {
-        content: '""',
-        position: 'absolute',
-        top: 0,
-        left: 0,
-        right: 0,
-        height: '4px',
-        background: 'linear-gradient(90deg, #900F0F 0%, #B20000 100%)',
-        borderRadius: '12px 12px 0 0',
-    },
-}));
-
-const PrimaryButton = styled(Button)(({ theme }) => ({
-    background: 'linear-gradient(135deg, #900F0F 0%, #B20000 100%)',
-    color: '#FFFFFF',
-    borderRadius: '12px',
-    padding: '12px 32px',
-    fontSize: '16px',
-    fontWeight: 600,
-    textTransform: 'none',
-    boxShadow: '0 4px 16px rgba(144, 15, 15, 0.3)',
-    minWidth: '200px',
-    '&:hover': {
-        background: 'linear-gradient(135deg, #B20000 0%, #E36264 100%)',
-        transform: 'translateY(-2px)',
-        boxShadow: '0 8px 24px rgba(144, 15, 15, 0.4)',
-    },
-    '&:disabled': {
-        background: '#E5E7EB',
-        color: '#9CA3AF',
-        transform: 'none',
-        boxShadow: 'none',
-    },
-    transition: 'all 0.3s ease-in-out',
-}));
+import {
+    StyledDialog,
+    StyledDialogTitle,
+    SelectionCard,
+    CustomerInfoCard,
+    PrimaryButton,
+    SecondaryButton,
+} from './styles/QuotationStyles';
 
 const Transition = React.forwardRef(function Transition(props, ref) {
     return <Slide direction="up" ref={ref} {...props} />;
@@ -539,21 +459,12 @@ const CreateQuotationModal = ({ open, onClose, pricingRequest, onSubmit }) => {
                         )}
                     </Box>
                     <Box display="flex" gap={2}>
-                        <Button 
-                            onClick={onClose} 
-                            disabled={isSubmitting}
-                            size="large"
-                            sx={{ 
-                                borderRadius: '12px',
-                                padding: '12px 24px',
-                                color: '#6B7280',
-                                '&:hover': {
-                                    backgroundColor: '#F3F4F6',
-                                },
-                            }}
+                        <SecondaryButton
+                            onClick={onClose}
+                            disabled={isSubmitting || selectedPricingItems.length === 0}
                         >
                             ยกเลิก
-                        </Button>
+                        </SecondaryButton>
                         <PrimaryButton
                             onClick={handleSubmit}
                             disabled={isSubmitting || selectedPricingItems.length === 0}

--- a/tnp-frontend/src/pages/Accounting/PricingIntegration/components/styles/QuotationStyles.js
+++ b/tnp-frontend/src/pages/Accounting/PricingIntegration/components/styles/QuotationStyles.js
@@ -1,0 +1,92 @@
+import { styled } from '@mui/material/styles';
+import { Box, Card, Dialog, DialogTitle, Paper } from '@mui/material';
+import { colors } from './DesignSystem';
+export { TNPPrimaryButton as PrimaryButton, TNPSecondaryButton as SecondaryButton } from './StyledComponents';
+
+export const StyledPaper = styled(Paper)(() => ({
+    background: 'linear-gradient(135deg, #FFFFFF 0%, #F8F9FA 100%)',
+    borderRadius: 16,
+    boxShadow: '0 8px 32px rgba(144, 15, 15, 0.08)',
+    border: '1px solid rgba(144, 15, 15, 0.1)',
+    overflow: 'hidden',
+}));
+
+export const SectionHeader = styled(Box)(() => ({
+    background: `linear-gradient(135deg, ${colors.primary.main} 0%, ${colors.secondary.main} 100%)`,
+    color: colors.primary.contrast,
+    padding: '16px 24px',
+    margin: '-1px -1px 24px -1px',
+    borderRadius: '16px 16px 0 0',
+    display: 'flex',
+    alignItems: 'center',
+    gap: '12px',
+}));
+
+export const InfoCard = styled(Card)(() => ({
+    backgroundColor: '#F8F9FA',
+    border: `1px solid ${colors.status.error}`,
+    borderRadius: 12,
+    '& .MuiCardContent-root': {
+        padding: 20,
+        '&:last-child': {
+            paddingBottom: 20,
+        },
+    },
+}));
+
+export const StyledDialog = styled(Dialog)(() => ({
+    '& .MuiDialog-paper': {
+        borderRadius: 16,
+        maxWidth: '1000px',
+        width: '90vw',
+        maxHeight: '90vh',
+        background: 'linear-gradient(135deg, #FFFFFF 0%, #F8F9FA 100%)',
+        boxShadow: '0 24px 48px rgba(144, 15, 15, 0.15)',
+    },
+}));
+
+export const StyledDialogTitle = styled(DialogTitle)(() => ({
+    background: `linear-gradient(135deg, ${colors.primary.main} 0%, ${colors.secondary.main} 100%)`,
+    color: colors.primary.contrast,
+    padding: '24px 32px',
+    position: 'relative',
+    '& .MuiTypography-root': {
+        fontSize: '1.5rem',
+        fontWeight: 600,
+    },
+}));
+
+export const SelectionCard = styled(Card)(({ selected }) => ({
+    cursor: 'pointer',
+    transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+    border: selected ? `2px solid ${colors.primary.main}` : '1px solid #E5E7EB',
+    backgroundColor: selected ? 'rgba(144, 15, 15, 0.02)' : '#FFFFFF',
+    transform: selected ? 'translateY(-2px)' : 'translateY(0)',
+    boxShadow: selected
+        ? '0 8px 25px rgba(144, 15, 15, 0.15)'
+        : '0 2px 8px rgba(0, 0, 0, 0.08)',
+    '&:hover': {
+        transform: 'translateY(-4px)',
+        boxShadow: '0 12px 32px rgba(144, 15, 15, 0.2)',
+        borderColor: selected ? colors.primary.main : colors.secondary.main,
+    },
+}));
+
+export const CustomerInfoCard = styled(Paper)(() => ({
+    background: 'linear-gradient(135deg, #F8F9FA 0%, #FFFFFF 100%)',
+    border: `1px solid ${colors.status.error}`,
+    borderRadius: 12,
+    padding: 20,
+    marginBottom: 24,
+    position: 'relative',
+    '&::before': {
+        content: '""',
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        height: 4,
+        background: `linear-gradient(90deg, ${colors.primary.main} 0%, ${colors.secondary.main} 100%)`,
+        borderRadius: '12px 12px 0 0',
+    },
+}));


### PR DESCRIPTION
## Summary
- consolidate quotation form and modal styling via shared `QuotationStyles`
- replace inline buttons with `TNPPrimaryButton` and `TNPSecondaryButton` variants

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6896a981980c8329854da83fca31b066