### PR TITLE
Brand quotation PDF with customizable color

### DIFF
--- a/tnp-backend/app/Http/Controllers/Api/V1/Accounting/QuotationController.php
+++ b/tnp-backend/app/Http/Controllers/Api/V1/Accounting/QuotationController.php
@@ -588,6 +588,9 @@ class QuotationController extends Controller
     {
         try {
             $options = $request->only(['format', 'orientation', 'showWatermark']);
+            if ($request->filled('primary_color')) {
+                $options['primaryColor'] = $request->input('primary_color');
+            }
             $result = $this->quotationService->generatePdf($id, $options);
             
             return response()->json([
@@ -618,6 +621,9 @@ class QuotationController extends Controller
     {
         try {
             $options = $request->only(['format', 'orientation', 'showWatermark']);
+            if ($request->filled('primary_color')) {
+                $options['primaryColor'] = $request->input('primary_color');
+            }
             return $this->quotationService->streamPdf($id, $options);
         } catch (\Exception $e) {
             return response()->json([
@@ -633,7 +639,11 @@ class QuotationController extends Controller
     public function downloadPdf(Request $request, $id)
     {
         try {
-            $result = $this->quotationService->generatePdf($id, $request->only(['format', 'orientation']));
+            $options = $request->only(['format', 'orientation']);
+            if ($request->filled('primary_color')) {
+                $options['primaryColor'] = $request->input('primary_color');
+            }
+            $result = $this->quotationService->generatePdf($id, $options);
             $filename = $result['filename'] ?? ('quotation-' . $id . '.pdf');
             $path = $result['path'] ?? null;
             if (!$path || !is_file($path)) {

--- a/tnp-backend/app/Services/Accounting/Pdf/QuotationPdfMasterService.php
+++ b/tnp-backend/app/Services/Accounting/Pdf/QuotationPdfMasterService.php
@@ -44,12 +44,16 @@ class QuotationPdfMasterService
             $isFinal = in_array($q->status, ['approved', 'sent', 'completed']);
 
             // เตรียมข้อมูลสำหรับ template
+            $primaryColor = $options['primaryColor'] ?? config('pdf.primary_color', '#900F0F');
+            unset($options['primaryColor']);
+
             $viewData = [
                 'quotation' => $q,
                 'customer' => $customer,
                 'groups' => $groups,
                 'summary' => $summary,
                 'isFinal' => $isFinal,
+                'primaryColor' => $primaryColor,
                 'options' => array_merge([
                     'format' => 'A4',
                     'orientation' => 'P',
@@ -158,19 +162,22 @@ class QuotationPdfMasterService
         $quotation = $data['quotation'];
         $customer = $data['customer'];
         $isFinal = $data['isFinal'];
+        $primaryColor = $data['primaryColor'] ?? config('pdf.primary_color', '#900F0F');
 
         // สร้าง header HTML
-    $headerHtml = View::make('accounting.pdf.quotation.partials.quotation-header', [
+        $headerHtml = View::make('accounting.pdf.quotation.partials.quotation-header', [
             'quotation' => $quotation,
             'customer' => $customer,
-            'isFinal' => $isFinal
+            'isFinal' => $isFinal,
+            'primaryColor' => $primaryColor,
         ])->render();
 
         // สร้าง footer HTML
-    $footerHtml = View::make('accounting.pdf.quotation.partials.quotation-footer', [
+        $footerHtml = View::make('accounting.pdf.quotation.partials.quotation-footer', [
             'quotation' => $quotation,
             'customer' => $customer,
-            'isFinal' => $isFinal
+            'isFinal' => $isFinal,
+            'primaryColor' => $primaryColor,
         ])->render();
 
         // กำหนด header/footer ให้ mPDF
@@ -296,12 +303,16 @@ class QuotationPdfMasterService
         $summary = $this->calculateSummary($q);
         $isFinal = in_array($q->status, ['approved', 'sent', 'completed']);
 
+        $primaryColor = $options['primaryColor'] ?? config('pdf.primary_color', '#900F0F');
+        unset($options['primaryColor']);
+
         $viewData = [
             'quotation' => $q,
             'customer' => $customer,
             'groups' => $groups,
             'summary' => $summary,
             'isFinal' => $isFinal,
+            'primaryColor' => $primaryColor,
             'options' => array_merge(['format' => 'A4', 'orientation' => 'P'], $options)
         ];
 

--- a/tnp-backend/app/Services/Accounting/QuotationService.php
+++ b/tnp-backend/app/Services/Accounting/QuotationService.php
@@ -807,9 +807,7 @@ class QuotationService
             $isFinal = in_array($quotation->status, ['approved', 'sent', 'completed']);
 
             // ใช้ Master PDF Service (mPDF) เป็นหลัก หากมี
-            $mpdfAvailable = class_exists(\Mpdf\Mpdf::class)
-                && class_exists(\Mpdf\Config\ConfigVariables::class)
-                && class_exists(\Mpdf\Config\FontVariables::class);
+            $mpdfAvailable = class_exists(\Mpdf\Mpdf::class);
 
             if ($mpdfAvailable) {
                 try {
@@ -901,9 +899,7 @@ class QuotationService
                                   ->findOrFail($quotationId);
                                   
             // ใช้ Master PDF Service (mPDF) เป็นหลัก หากมี
-            $mpdfAvailable = class_exists(\Mpdf\Mpdf::class)
-                && class_exists(\Mpdf\Config\ConfigVariables::class)
-                && class_exists(\Mpdf\Config\FontVariables::class);
+            $mpdfAvailable = class_exists(\Mpdf\Mpdf::class);
 
             if ($mpdfAvailable) {
                 try {

--- a/tnp-backend/app/Services/Accounting/QuotationService.php
+++ b/tnp-backend/app/Services/Accounting/QuotationService.php
@@ -829,7 +829,8 @@ class QuotationService
                 
                 // Fallback to FPDF only if mPDF completely fails
                 $fpdfService = app(\App\Services\Accounting\Pdf\QuotationPdfService::class);
-                $pdfPath = $fpdfService->render($quotation);
+                $primary = $options['primaryColor'] ?? config('pdf.primary_color', '#900F0F');
+                $pdfPath = $fpdfService->render($quotation, ['primaryColor' => $primary]);
                 $filename = basename($pdfPath);
                 $pdfUrl = url('storage/pdfs/quotations/' . $filename);
                 $fileSize = is_file($pdfPath) ? filesize($pdfPath) : 0;
@@ -877,7 +878,8 @@ class QuotationService
             // Fallback to FPDF
             $fpdfService = app(\App\Services\Accounting\Pdf\QuotationPdfService::class);
             $quotation = Quotation::with(['customer', 'company', 'items'])->findOrFail($quotationId);
-            $pdfPath = $fpdfService->render($quotation);
+            $primary = $options['primaryColor'] ?? config('pdf.primary_color', '#900F0F');
+            $pdfPath = $fpdfService->render($quotation, ['primaryColor' => $primary]);
             
             $filename = sprintf('quotation-%s.pdf', $quotation->number ?? $quotation->id);
             

--- a/tnp-backend/config/pdf.php
+++ b/tnp-backend/config/pdf.php
@@ -12,6 +12,7 @@ return [
     'margin_header'          => 0,
     'margin_footer'          => 0,
     'orientation'            => 'P',
+    'primary_color'         => '#900F0F',
 
     'title'                  => 'Laravel mPDF',
     'author'                 => 'YourApp',

--- a/tnp-backend/resources/views/accounting/pdf/quotation/quotation-master.blade.php
+++ b/tnp-backend/resources/views/accounting/pdf/quotation/quotation-master.blade.php
@@ -149,56 +149,28 @@
       };
     @endphp
 
-    {{-- Summary and Notes Section (Fixed Layout) --}}
-    <div class="summary-notes-container">
-      <table class="summary-notes-wrapper">
-        <tr>
-          {{-- Notes Section --}}
-          <td class="notes-cell">
-            <h3>หมายเหตุ</h3>
-            <div class="notes-section">
-              {!! !empty($quotation->notes) ? nl2br(e($quotation->notes)) : 'ไม่มีหมายเหตุ' !!}
-            </div>
-          </td>
-          
-          {{-- Spacer --}}
-          <td class="spacer-cell"></td>
-          
-          {{-- Summary Section --}}
-          <td class="summary-cell">
-            <h3 class="summary-header">สรุปยอดเงิน</h3>
-            <div class="summary-section">
-              {{-- Subtotal --}}
-              <table class="summary-row">
-                <tr>
-                  <td class="summary-label">รวมเป็นเงิน</td>
-                  <td class="summary-amount">{{ number_format($summary['subtotal'] ?? 0, 2) }} บาท</td>
-                </tr>
-              </table>
-              
-              {{-- Tax --}}
-              <table class="summary-row">
-                <tr>
-                  <td class="summary-label">ภาษีมูลค่าเพิ่ม 7%</td>
-                  <td class="summary-amount">{{ number_format($summary['tax'] ?? 0, 2) }} บาท</td>
-                </tr>
-              </table>
-              
-              {{-- Total --}}
-              <table class="summary-row total-row">
-                <tr>
-                  <td class="summary-label">รวมเป็นเงินทั้งสิ้น</td>
-                  <td class="summary-amount">
-                    {{ number_format($summary['total'] ?? 0, 2) }} บาท
-                    <div class="reading">({{ $thaiBahtText($summary['total'] ?? 0) }})</div>
-                  </td>
-                </tr>
-              </table>
-            </div>
-          </td>
-        </tr>
-      </table>
-    </div>
+    {{-- Summary and Notes Section --}}
+    <table class="notes-summary-table">
+      <tr>
+        <td class="notes-box" rowspan="3">
+          <strong>หมายเหตุ</strong><br/>
+          {!! !empty($quotation->notes) ? nl2br(e($quotation->notes)) : 'ไม่มีหมายเหตุ' !!}
+        </td>
+        <td class="summary-label">รวมเป็นเงิน</td>
+        <td class="summary-value">{{ number_format($summary['subtotal'] ?? 0, 2) }} บาท</td>
+      </tr>
+      <tr>
+        <td class="summary-label">ภาษีมูลค่าเพิ่ม 7%</td>
+        <td class="summary-value">{{ number_format($summary['tax'] ?? 0, 2) }} บาท</td>
+      </tr>
+      <tr class="total-row">
+        <td class="summary-label">รวมเป็นเงินทั้งสิ้น</td>
+        <td class="summary-value">
+          {{ number_format($summary['total'] ?? 0, 2) }} บาท
+          <div class="reading">({{ $thaiBahtText($summary['total'] ?? 0) }})</div>
+        </td>
+      </tr>
+    </table>
 
     {{-- ลายเซ็น --}}
     <div class="signature-section">

--- a/tnp-backend/resources/views/accounting/pdf/quotation/quotation-master.css
+++ b/tnp-backend/resources/views/accounting/pdf/quotation/quotation-master.css
@@ -8,9 +8,9 @@ body{
   padding:20pt;
 }
 
-h1{font-size:20pt;font-weight:bold;margin:0 0 8pt;color:#2c3e50}
-h2{font-size:16pt;font-weight:bold;margin:12pt 0 6pt;color:#34495e}
-h3{font-size:13pt;font-weight:bold;margin:10pt 0 6pt;color:#34495e}
+h1{font-size:20pt;font-weight:bold;margin:0 0 8pt;color:#900F0F}
+h2{font-size:16pt;font-weight:bold;margin:12pt 0 6pt;color:#900F0F}
+h3{font-size:13pt;font-weight:bold;margin:10pt 0 6pt;color:#900F0F}
 
 /* ===== Reset any potential Bootstrap conflicts ===== */
 * {
@@ -25,8 +25,9 @@ h3{font-size:13pt;font-weight:bold;margin:10pt 0 6pt;color:#34495e}
 
 /* ===== Info Box ===== */
 .info-box{
-  background:#f8f9fa;
+  background:#fdf0f0;
   border:1px solid #e9ecef;
+  border-left:4pt solid #900F0F;
   border-radius:6pt;
   padding:12pt;
   margin-bottom:15pt;
@@ -57,8 +58,9 @@ table{
 }
 
 .items-table thead th{
-  border-bottom:2px solid #9fb3c8;
-  background:#eef2f5;
+  border-bottom:2px solid #700b0b;
+  background:#900F0F;
+  color:#fff;
   text-align:center;
   font-weight: bold;
 }
@@ -68,6 +70,9 @@ table{
 .items-table .qty{width:14%;text-align:center}
 .items-table .price{width:13%;text-align:right}
 .items-table .amount{width:13%;text-align:right}
+
+.items-table tbody tr:nth-child(even) td{background:#fdf0f0;}
+.items-table td.title{background:#f5e6e6;color:#900F0F;font-weight:bold;}
 
 /* Group styling */
 .group-body{page-break-inside:avoid}
@@ -96,127 +101,52 @@ table{
 
 .meta-light{color:#6e7b88;font-weight:normal}
 
-/* ===== Summary and Notes Section (Fixed Layout) ===== */
-.summary-notes-container {
-  width: 100%;
-  margin: 24pt 0;
-  page-break-inside: avoid;
-  clear: both;
+/* ===== Summary and Notes Table ===== */
+.notes-summary-table{
+  width:100%;
+  border-collapse:collapse;
+  margin:20pt 0;
 }
 
-.summary-notes-wrapper {
-  width: 100%;
-  border-collapse: separate;
-  border-spacing: 15pt 0;
-  table-layout: fixed;
-}
-
-.notes-cell {
-  width: 45%;
-  vertical-align: top;
-  padding: 0;
-  border: none;
-}
-
-.notes-cell h3 {
-  font-size: 13pt;
-  font-weight: bold;
-  margin: 0 0 200pt 0;
-  padding: 0;
-  color: #34495e;
-  line-height: 1.2;
-}
-
-.spacer-cell {
-  width: 10%;
-  padding: 0;
-  border: none;
-}
-
-.summary-cell {
-  width: 45%;
-  vertical-align: top;
-  padding: 0;
-  border: none;
-}
-
-/* Notes section */
-.notes-section{
-  
-  border-left:4pt ;
-  padding:15pt;
-  border-radius:4pt;
-  min-height:120pt;
-  font-size: 14pt;
-  width: 100%;
-  box-sizing: border-box;
-  display: block;
-  margin-top: 10pt;
-  clear: both;
-}
-
-/* Summary section */
-.summary-section{
-  background:#fff;
+.notes-summary-table td{
   border:1px solid #dee2e6;
-  border-radius:6pt;
-  overflow:hidden;
-  min-height:120pt;
-  width: 100%;
-  box-sizing: border-box;
-  display: block;
+  padding:8pt 10pt;
+  vertical-align:top;
 }
 
-.summary-header {
-  text-align: center;
-  margin: 0 0 12pt 0;
-  padding: 0;
-  font-size: 13pt;
-  font-weight: bold;
-  color: #34495e;
+.notes-summary-table .notes-box{
+  width:60%;
+  background:#fdf0f0;
+  border-left:4pt solid #900F0F;
+  font-size:14pt;
 }
 
-.summary-row{
-  width: 100%;
-  border-collapse: collapse;
-  margin: 0;
-  display: table;
-}
-
-.summary-row td {
-  padding: 12pt 15pt;
-  border-bottom: 1px solid #e9ecef;
-  display: table-cell;
-}
-
-.summary-label{
+.notes-summary-table .summary-label{
+  width:20%;
   text-align:right;
   font-weight:bold;
-  color:#2c3e50;
-  width: 60%;
-  white-space: nowrap;
+  color:#900F0F;
+  white-space:nowrap;
 }
 
-.summary-amount{
+.notes-summary-table .summary-value{
+  width:20%;
   text-align:right;
   white-space:nowrap;
-  font-size:12pt;
-  width: 40%;
 }
 
-.total-row {
-  background:#e3f2fd !important;
+.notes-summary-table .total-row td{
+  background:#900F0F;
+  color:#fff;
+  font-weight:bold;
 }
 
-.total-row td {
-  background:#e3f2fd !important;
+.notes-summary-table .total-row .summary-value{
+  color:#fff;
 }
 
-.total-row .summary-label,
-.total-row .summary-amount{
-  color:#1565c0 !important;
-  font-weight: bold !important;
-  font-size: 14pt !important;
+.notes-summary-table .total-row .reading{
+  color:#fff;
 }
 
 .reading{
@@ -224,7 +154,7 @@ table{
   font-size:10pt;
   margin-top:4pt;
   font-style:italic;
-  display: block;
+  display:block;
 }
 
 /* ===== Signature Section ===== */
@@ -249,7 +179,7 @@ table{
 .signature-box{
   width:200pt;
   height:60pt;
-  border-bottom:1pt solid #333;
+  border-bottom:1pt solid #900F0F;
   margin-bottom:8pt;
   display:block;
   margin-left:auto;

--- a/tnp-backend/resources/views/pdf/partials/quotation-footer.blade.php
+++ b/tnp-backend/resources/views/pdf/partials/quotation-footer.blade.php
@@ -1,21 +1,15 @@
 {{-- resources/views/pdf/partials/quotation-footer.blade.php --}}
-<div style="border-top: 1pt solid #bdc3c7; margin-top: 5pt; padding-top: 8pt;">
+<div style="border-top: 2pt solid {{ $primaryColor }}; margin-top: 5pt; padding-top: 8pt;">
     <table style="width: 100%; border-collapse: collapse; font-family: 'thsarabun', sans-serif; font-size: 10pt; color: #7f8c8d;">
         <tr>
-            
-            
-            
-            
-            <td style="width: 33%; text-align: right; vertical-align: top;">
-                {{-- เลขหน้าและข้อมูลเอกสาร --}}
-                <div style="font-weight: bold; color: #2c3e50;">
+            <td style="width: 50%; text-align: left; vertical-align: top;">
+                {{ $quotation->company->name ?? 'บริษัทของคุณ' }} | โทร: {{ $quotation->company->phone ?? '-' }}
+            </td>
+            <td style="width: 50%; text-align: right; vertical-align: top;">
+                <div style="font-weight: bold; color: {{ $primaryColor }};">
                     หน้า {PAGENO} จาก {nbpg}
                 </div>
-                
-                
             </td>
         </tr>
     </table>
-    
-    
 </div>

--- a/tnp-backend/resources/views/pdf/partials/quotation-header.blade.php
+++ b/tnp-backend/resources/views/pdf/partials/quotation-header.blade.php
@@ -36,11 +36,14 @@
                 โทร: {{ $quotation->company->phone ?? '-' }} <br/>
                 เลขประจำตัวผู้เสียภาษี: {{ $quotation->company->tax_id ?? '-' }}
             </div>
+            <div style="font-size: 11pt; color: {{ $primaryColor }}; margin-top: 4pt;">
+                {{ $quotation->company->tagline ?? 'ผู้ผลิตและจำหน่ายเสื้อคุณภาพ' }}
+            </div>
         </td>
         
         <td style="width: 45%; vertical-align: top; text-align: right; padding: 8pt;">
             {{-- หัวข้อเอกสาร --}}
-            <div style="font-size: 20pt; font-weight: bold; color: #e74c3c; margin-bottom: 5pt;">
+            <div style="font-size: 20pt; font-weight: bold; color: {{ $primaryColor }}; margin-bottom: 5pt;">
                 ใบเสนอราคา
             </div>
             
@@ -79,4 +82,4 @@
 </table>
 
 {{-- เส้นแบ่ง --}}
-<div style="border-bottom: 2pt solid #34495e; margin: 8pt 0;"></div>
+<div style="border-bottom: 2pt solid {{ $primaryColor }}; margin: 8pt 0;"></div>


### PR DESCRIPTION
## Summary
- Add configurable `primary_color` for PDFs and pass it through QuotationPdfMasterService
- Restyle quotation header, footer and CSS with brand color #900F0F and improved table readability
- Allow overriding primary color via API options
- Reorganize quotation summary and notes into a single table for a cleaner, official layout

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused; No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a59d0c467c8329acf8bf7010f26e82