### PR TITLE
Handle blank page when rendering signature

### DIFF
--- a/tnp-backend/app/Services/Accounting/Pdf/QuotationPdfMasterService.php
+++ b/tnp-backend/app/Services/Accounting/Pdf/QuotationPdfMasterService.php
@@ -286,6 +286,15 @@ class QuotationPdfMasterService
 
             $sigHtml = View::make('pdf.partials.quotation-signature')->render();
 
+            // หากหน้านี้แทบไม่มีเนื้อหาเลย (เกิดจากการขึ้นหน้าใหม่อัตโนมัติ)
+            // ให้ถือว่าเป็นพื้นที่ว่างทั้งหมดและวางลายเซ็นในหน้านี้ทันที
+            if ($currentY <= 5) {
+                $mpdf->SetY(-($requiredHeight + $bottomPadding));
+                $mpdf->WriteHTML($sigHtml, HTMLParserMode::HTML_BODY);
+                Log::info('Signature adaptive: reused existing blank page', compact('currentY'));
+                return;
+            }
+
             if ($remaining >= ($requiredHeight + $bottomPadding)) {
                 // มีที่พอ: ใช้ block container ที่มี margin-top = (remaining - requiredHeight - bottomPadding)
                 $pushDown = max($remaining - $requiredHeight - $bottomPadding, 0);


### PR DESCRIPTION
## Summary
- Detect near-empty trailing page and reuse it for the signature without adding an extra blank page
- Keep adaptive logic for placing signature on the same page or a new one when space is insufficient

## Testing
- `composer install`
- `./vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused; Missing application encryption key)*

------
https://chatgpt.com/codex/tasks/task_e_68ac398d6c688329a0c5e48fa49520df